### PR TITLE
Make division colour and title arrays static

### DIFF
--- a/src/arc/ArcGlobals.as
+++ b/src/arc/ArcGlobals.as
@@ -179,6 +179,9 @@ package arc
         public var filterLevelHigh:int = 120;
 
         public var configMPSize:int = 10;
+        
+        public static var divisionColor:Array = [0xC27BA0, 0x8E7CC3, 0x6D9EEB, 0x93C47D, 0xFFD966, 0xE06666, 0x919C86, 0xD2C7AC, 0xBF0000];
+        public static var divisionTitle:Array = ["Novice", "Intermediate", "Advanced", "Expert", "Master", "Guru", "Legendary", "Godly", "Developer"];
 
         public function mpLoad():void
         {

--- a/src/arc/mp/MultiplayerChat.as
+++ b/src/arc/mp/MultiplayerChat.as
@@ -271,8 +271,8 @@ package arc.mp
 
         public static function textFormatLevel(user:Object):String
         {
-            var divisionColor:Array = [0xC27BA0, 0x8E7CC3, 0x6D9EEB, 0x93C47D, 0xFFD966, 0xE06666, 0x919C86, 0xD2C7AC, 0xBF0000];
-            var divisionTitle:Array = ["Novice", "Intermediate", "Advanced", "Expert", "Master", "Guru", "Legendary", "Godly", "Developer"];
+            var divisionColor:Array = ArcGlobals.divisionColor;
+            var divisionTitle:Array = ArcGlobals.divisionTitle;
             var color:int;
             var division:int;
             var title:String;

--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -371,8 +371,8 @@ package arc.mp
                colour = "#101010";
                }
              */
-            var divisionColor:Array = [0xC27BA0, 0x8E7CC3, 0x6D9EEB, 0x93C47D, 0xFFD966, 0xE06666, 0x919C86, 0xD2C7AC, 0xBF0000];
-            var divisionTitle:Array = ["Novice", "Intermediate", "Advanced", "Expert", "Master", "Guru", "Legendary", "Godly", "Developer"];
+            var divisionColor:Array = ArcGlobals.divisionColor;
+            var divisionTitle:Array = ArcGlobals.divisionTitle;
             var color:int;
             var division:int;
             var title:String;


### PR DESCRIPTION
Resolves the changes requested in the review in closed PR #28.
Division colour and title arrays are put into ArcGlobals as static variables to enable data reuse.