### PR TITLE
Updated Token Display Box Height

### DIFF
--- a/src/menu/TokenItem.as
+++ b/src/menu/TokenItem.as
@@ -79,7 +79,7 @@ package menu
             messageText.htmlText = "<font face=\"" + Language.UNI_FONT_NAME + "\" color=\"#FFFFFF\" size=\"12\"><b>" + messageString + "</b></font>";
 
             //- Make Display
-            var box:Box = new Box(577, Math.max(54, (32 + (messageText.numLines * 15))), false);
+            var box:Box = new Box(577, Math.max(54, (32 + (messageText.numLines * 17))), false);
 
             //- Name
             var nameText:Text = new Text(token_info["name"], 14);


### PR DESCRIPTION
Additional height added to token display boxes for token descriptions that are 5+ lines.

Before:
![image](https://user-images.githubusercontent.com/2185274/84476781-a5643d00-ac5c-11ea-9ed8-2515cf988204.png)

After:
![image](https://user-images.githubusercontent.com/2185274/84476877-c62c9280-ac5c-11ea-984f-703d2679ee2c.png)

Small change, but I'm still learning Github / AS and wanting to familiarize myself with the project.