### PR TITLE
Add checkbox for vertically flipping the marker result graph

### DIFF
--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -119,6 +119,7 @@ package
             public var air_useLocalFileCache:Boolean = false;
             public var air_autoSaveLocalReplays:Boolean = false;
             public var air_useVSync:Boolean = true;
+            public var air_vFlipResultGraph:Boolean = false;
 
             public var sql_connect:Boolean = false;
             public var sql_conn:SQLConnection;
@@ -129,6 +130,7 @@ package
                 air_useLocalFileCache = LocalStore.getVariable("air_useLocalFileCache", false);
                 air_autoSaveLocalReplays = LocalStore.getVariable("air_autoSaveLocalReplays", false);
                 air_useVSync = LocalStore.getVariable("air_useVSync", false);
+                air_vFlipResultGraph = LocalStore.getVariable("air_vFlipResultGraph", false);
             }
 
             public function initSQLConnection():void

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -523,7 +523,8 @@ package game
             var graphWidth:int = 718;
             var graphHeight:int = 117;
             var posX:Number;
-            var posY:Number;
+            var posY:Number = 0;
+            var flipGraph:Boolean = _gvars.air_vFlipResultGraph;
 
             var ratioX:Number = graphWidth;
             var ratioY:Number = graphHeight;
@@ -591,17 +592,38 @@ package game
                         default:
                             continue;
                     }
+                    if (flipGraph)
+                    {
+                        posY += jn_rect_height;
+                    }
+                    else
+                    {
+                        posY = ((jncj.t * -1) - MIN_TIME) * ratioY;
+                    }
+
                     graphDraw.graphics.beginFill(bgColor, 0.25);
-                    graphDraw.graphics.drawRect(0, ((jncj.t * -1) - MIN_TIME) * ratioY - jn_rect_height, graphWidth, jn_rect_height);
+                    graphDraw.graphics.drawRect(0, posY - jn_rect_height, graphWidth, jn_rect_height);
                     graphDraw.graphics.endFill();
                 }
+
                 // Draw Judge Regions Dividers
+                posY = 0;
                 graphDraw.graphics.lineStyle(1, 0x000000, 0.25);
                 for (jn = 1; jn < judgeSettings.length - 1; jn++)
                 {
                     jncj = judgeSettings[jn];
-                    graphDraw.graphics.moveTo(0, ((jncj.t * -1) - MIN_TIME) * ratioY);
-                    graphDraw.graphics.lineTo(graphWidth, ((jncj.t * -1) - MIN_TIME) * ratioY);
+                    if (flipGraph)
+                    {
+                        jnnj = judgeSettings[jn + 1];
+                        jn_rect_height = (jnnj.t - jncj.t) * ratioY;
+                        posY += jn_rect_height;
+                    }
+                    else
+                    {
+                        posY = ((jncj.t * -1) - MIN_TIME) * ratioY;
+                    }
+                    graphDraw.graphics.moveTo(0, posY);
+                    graphDraw.graphics.lineTo(graphWidth, posY);
                 }
 
                 // Draw Hit Markers
@@ -635,15 +657,20 @@ package game
                                 break;
                             case 0:
                             default:
-                                posY = GAP_TIME * ratioY;
+                                posY = 0;
                                 bgColor = 0xff0000;
                                 break;
                         }
                     }
                     else
                     {
-                        posY = GAP_TIME * ratioY;
+                        posY = 0;
                         bgColor = 0xff0000;
+                    }
+
+                    if (flipGraph)
+                    {
+                        posY = graphHeight - posY;
                     }
 
                     graphDraw.graphics.lineStyle(1, bgColor, 1);

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -148,6 +148,7 @@ package popups
             private var useCacheCheckbox:checkBox;
             private var autoSaveLocalCheckbox:checkBox;
             private var useVSyncCheckbox:checkBox;
+            private var vFlipResultGraphCheckbox:checkBox;
         }
 
         public function PopupOptions(myParent:MenuPanel)
@@ -1129,6 +1130,19 @@ package popups
                     useVSyncCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                     box.addChild(useVSyncCheckbox);
                     yOff += 30;
+
+                    var vFlipResultGraphCheckboxText:Text = new Text("Flip Marker Result Graph Vertically");
+                    vFlipResultGraphCheckboxText.x = xOff + 22;
+                    vFlipResultGraphCheckboxText.y = yOff;
+                    box.addChild(vFlipResultGraphCheckboxText);
+                    yOff += 2;
+
+                    vFlipResultGraphCheckbox = new checkBox();
+                    vFlipResultGraphCheckbox.x = xOff + 2;
+                    vFlipResultGraphCheckbox.y = yOff;
+                    vFlipResultGraphCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
+                    box.addChild(vFlipResultGraphCheckbox);
+                    yOff += 30;
                 }
 
                 ///- Col 2
@@ -1725,6 +1739,11 @@ package popups
                     stage.vsyncEnabled = _gvars.air_useVSync;
                     _gvars.gameMain.addAlert("Set VSYNC: " + stage.vsyncEnabled, 120, Alert.RED);
                 }
+                if (e.target == vFlipResultGraphCheckbox)
+                {
+                    _gvars.air_vFlipResultGraph = !_gvars.air_vFlipResultGraph;
+                    LocalStore.setVariable("air_vFlipResultGraph", _gvars.air_vFlipResultGraph);
+                }
             }
             // Set Settings
             setSettings();
@@ -2001,6 +2020,7 @@ package popups
                     autoSaveLocalCheckbox.gotoAndStop(_gvars.air_autoSaveLocalReplays ? 2 : 1);
                     useCacheCheckbox.gotoAndStop(_gvars.air_useLocalFileCache ? 2 : 1);
                     useVSyncCheckbox.gotoAndStop(_gvars.air_useVSync ? 2 : 1);
+                    vFlipResultGraphCheckbox.gotoAndStop(_gvars.air_vFlipResultGraph ? 2 : 1);
                 }
             }
             // Save Local


### PR DESCRIPTION
Resolves #72. Also includes changes requested from players on displaying misses at the top of unflipped graphs and at the bottom of flipped graphs.