### PR TITLE
Workflow: Rename master to main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,11 +3,11 @@ name: Check
 on:
   push:
     branches:
-      - master
+      - main
       - feat/workflow
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Actions not firing because of branch rename.