### PR TITLE
Make division level array static

### DIFF
--- a/src/arc/ArcGlobals.as
+++ b/src/arc/ArcGlobals.as
@@ -184,6 +184,29 @@ package arc
         public static const divisionTitle:Array = ["Novice", "Intermediate", "Advanced", "Expert", "Master", "Guru", "Legendary", "Godly", "Developer"];
         public static const divisionLevel:Array = [0, 26, 50, 59, 69, 83, 94, 101, 122];
         
+        public static function getDivisionColor(level:int):int
+        {
+            return divisionColor[getDivisionNumber(level)];
+        }
+
+        public static function getDivisionTitle(level:int):String
+        {
+            return divisionTitle[getDivisionNumber(level)];
+        }
+
+        public static function getDivisionNumber(level:int):int
+        {
+            var div:int;
+            for (div = divisionLevel.length - 1; div >= 0; --div)
+            {
+                if (level >= divisionLevel[div])
+                {
+                    break;
+                }
+            }
+            return div;
+        }
+        
         public function mpLoad():void
         {
             var save:SharedObject = SharedObject.getLocal(Constant.LOCAL_SO_NAME);

--- a/src/arc/ArcGlobals.as
+++ b/src/arc/ArcGlobals.as
@@ -180,9 +180,10 @@ package arc
 
         public var configMPSize:int = 10;
         
-        public static var divisionColor:Array = [0xC27BA0, 0x8E7CC3, 0x6D9EEB, 0x93C47D, 0xFFD966, 0xE06666, 0x919C86, 0xD2C7AC, 0xBF0000];
-        public static var divisionTitle:Array = ["Novice", "Intermediate", "Advanced", "Expert", "Master", "Guru", "Legendary", "Godly", "Developer"];
-
+        public static const divisionColor:Array = [0xC27BA0, 0x8E7CC3, 0x6D9EEB, 0x93C47D, 0xFFD966, 0xE06666, 0x919C86, 0xD2C7AC, 0xBF0000];
+        public static const divisionTitle:Array = ["Novice", "Intermediate", "Advanced", "Expert", "Master", "Guru", "Legendary", "Godly", "Developer"];
+        public static const divisionLevel:Array = [0, 26, 50, 59, 69, 83, 94, 101, 122];
+        
         public function mpLoad():void
         {
             var save:SharedObject = SharedObject.getLocal(Constant.LOCAL_SO_NAME);

--- a/src/arc/mp/MultiplayerChat.as
+++ b/src/arc/mp/MultiplayerChat.as
@@ -271,70 +271,26 @@ package arc.mp
 
         public static function textFormatLevel(user:Object):String
         {
-            var divisionColor:Array = ArcGlobals.divisionColor;
-            var divisionTitle:Array = ArcGlobals.divisionTitle;
-            var color:int;
-            var division:int;
-            var title:String;
-            if (user.userLevel > 121)
+            const divisionColor:Array = ArcGlobals.divisionColor;
+            const divisionTitle:Array = ArcGlobals.divisionTitle;
+            const divisionLevel:Array = ArcGlobals.divisionLevel;
+            const level:int = user.userLevel;
+
+            var i:int;
+            for (i = divisionLevel.length - 1; i >= 0; --i)
             {
-                color = divisionColor[8];
-                title = divisionTitle[8];
-                division = 9;
-            }
-            else if (user.userLevel >= 101)
-            {
-                color = divisionColor[7];
-                title = divisionTitle[7];
-                division = 8;
-            }
-            else if (user.userLevel >= 94)
-            {
-                color = divisionColor[6];
-                title = divisionTitle[6];
-                division = 7;
-            }
-            else if (user.userLevel >= 83)
-            {
-                color = divisionColor[5];
-                title = divisionTitle[5];
-                division = 6;
-            }
-            else if (user.userLevel >= 69)
-            {
-                color = divisionColor[4];
-                title = divisionTitle[4];
-                division = 5;
-            }
-            else if (user.userLevel >= 59)
-            {
-                color = divisionColor[3];
-                title = divisionTitle[3];
-                division = 4;
-            }
-            else if (user.userLevel >= 50)
-            {
-                color = divisionColor[2];
-                title = divisionTitle[2];
-                division = 3;
-            }
-            else if (user.userLevel >= 26)
-            {
-                color = divisionColor[1];
-                title = divisionTitle[1];
-                division = 2;
-            }
-            else
-            {
-                color = divisionColor[0];
-                title = divisionTitle[0];
-                division = 1;
+                if (level >= divisionLevel[i])
+                {
+                    break;
+                }
             }
 
-            var dulledColour:String = textDullColour(color, 1).toString(16);
+            const color:int = divisionColor[i];
+            const title:String = divisionTitle[i];
+            const dulledColour:String = textDullColour(color, 1).toString(16);
             //return textFormatColour(" ", "#" + dulledColour);
             //return textFormatColour("D" + division + " [" + user.userLevel + "] ", "#" + dulledColour);
-            return textFormatColour("Lv." + user.userLevel + " (" + title + ") ", "#" + dulledColour);
+            return textFormatColour("Lv." + level + " (" + title + ") ", "#" + dulledColour);
         }
 
         public static function textFormatServerMessage(user:Object, message:String):String

--- a/src/arc/mp/MultiplayerChat.as
+++ b/src/arc/mp/MultiplayerChat.as
@@ -271,22 +271,9 @@ package arc.mp
 
         public static function textFormatLevel(user:Object):String
         {
-            const divisionColor:Array = ArcGlobals.divisionColor;
-            const divisionTitle:Array = ArcGlobals.divisionTitle;
-            const divisionLevel:Array = ArcGlobals.divisionLevel;
             const level:int = user.userLevel;
-
-            var i:int;
-            for (i = divisionLevel.length - 1; i >= 0; --i)
-            {
-                if (level >= divisionLevel[i])
-                {
-                    break;
-                }
-            }
-
-            const color:int = divisionColor[i];
-            const title:String = divisionTitle[i];
+            const color:int = ArcGlobals.getDivisionColor(level);
+            const title:String = ArcGlobals.getDivisionTitle(level);
             const dulledColour:String = textDullColour(color, 1).toString(16);
             //return textFormatColour(" ", "#" + dulledColour);
             //return textFormatColour("D" + division + " [" + user.userLevel + "] ", "#" + dulledColour);

--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -371,69 +371,25 @@ package arc.mp
                colour = "#101010";
                }
              */
-            var divisionColor:Array = ArcGlobals.divisionColor;
-            var divisionTitle:Array = ArcGlobals.divisionTitle;
-            var color:int;
-            var division:int;
-            var title:String;
-            if (room.level > 121)
+            const divisionColor:Array = ArcGlobals.divisionColor;
+            const divisionTitle:Array = ArcGlobals.divisionTitle;
+            const divisionLevel:Array = ArcGlobals.divisionLevel;
+            const level:int = room.level;
+
+            var i:int;
+            for (i = divisionLevel.length - 1; i >= 0; --i)
             {
-                color = divisionColor[8];
-                title = divisionTitle[8];
-                division = 9;
-            }
-            else if (room.level >= 101)
-            {
-                color = divisionColor[7];
-                title = divisionTitle[7];
-                division = 8;
-            }
-            else if (room.level >= 94)
-            {
-                color = divisionColor[6];
-                title = divisionTitle[6];
-                division = 7;
-            }
-            else if (room.level >= 83)
-            {
-                color = divisionColor[5];
-                title = divisionTitle[5];
-                division = 6;
-            }
-            else if (room.level >= 69)
-            {
-                color = divisionColor[4];
-                title = divisionTitle[4];
-                division = 5;
-            }
-            else if (room.level >= 59)
-            {
-                color = divisionColor[3];
-                title = divisionTitle[3];
-                division = 4;
-            }
-            else if (room.level >= 50)
-            {
-                color = divisionColor[2];
-                title = divisionTitle[2];
-                division = 3;
-            }
-            else if (room.level >= 26)
-            {
-                color = divisionColor[1];
-                title = divisionTitle[1];
-                division = 2;
-            }
-            else
-            {
-                color = divisionColor[0];
-                title = divisionTitle[0];
-                division = 1;
+                if (level >= divisionLevel[i])
+                {
+                    break;
+                }
             }
 
-            var dulledColour:String = MultiplayerChat.textDullColour(color, 1).toString(16);
-            var roomName:String = "(" + title + ")";
-            var spectatorString:String = (room.spectatorCount > 0) ? "+" + room.spectatorCount + " " : "";
+            const color:int = divisionColor[i];
+            const title:String = divisionTitle[i];
+            const dulledColour:String = MultiplayerChat.textDullColour(color, 1).toString(16);
+            const roomName:String = "(" + title + ")";
+            const spectatorString:String = (room.spectatorCount > 0) ? "+" + room.spectatorCount + " " : "";
 
             return MultiplayerChat.textFormatSize(room.playerCount + "/2 " + spectatorString, "-1") + MultiplayerChat.textFormatColour(MultiplayerChat.textEscape((room.isPrivate ? "!" : "") + roomName), "#" + dulledColour) + " " + room.name;
         }

--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -371,22 +371,10 @@ package arc.mp
                colour = "#101010";
                }
              */
-            const divisionColor:Array = ArcGlobals.divisionColor;
-            const divisionTitle:Array = ArcGlobals.divisionTitle;
-            const divisionLevel:Array = ArcGlobals.divisionLevel;
             const level:int = room.level;
+            const color:int = ArcGlobals.getDivisionColor(level);
+            const title:String = ArcGlobals.getDivisionTitle(level);
 
-            var i:int;
-            for (i = divisionLevel.length - 1; i >= 0; --i)
-            {
-                if (level >= divisionLevel[i])
-                {
-                    break;
-                }
-            }
-
-            const color:int = divisionColor[i];
-            const title:String = divisionTitle[i];
             const dulledColour:String = MultiplayerChat.textDullColour(color, 1).toString(16);
             const roomName:String = "(" + title + ")";
             const spectatorString:String = (room.spectatorCount > 0) ? "+" + room.spectatorCount + " " : "";


### PR DESCRIPTION
Put division levels into a static array in ArcGlobals, which enabled refactoring textFormatLevel() and nameRoom().