### PR TITLE
Add rcubed-contributors to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/ @rcubed-contributors

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/ @rcubed-contributors
+* @flashflashrevolution/rcubed-contributors


### PR DESCRIPTION
This should assist in automatically assigning reviews to new PRs.
We can eventually expand this to be more specific.
