### PR TITLE
Enable editing songs in the current queue

### DIFF
--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -75,6 +75,7 @@ package menu
 
         private var songItemContextMenu:ContextMenu;
         private var songItemContextMenuItem:ContextMenuItem;
+        private var removeFromQueueCMItemIndex:int = 1;
         private var isQueuePlaylist:Boolean = false;
 
         ///- Constructor
@@ -162,6 +163,7 @@ package menu
                     songItemContextMenuItem = new ContextMenuItem("Song Options");
                     songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_songOptionsContextSelect);
                     songItemContextMenu.customItems.push(songItemContextMenuItem);
+                    removeFromQueueCMItemIndex = 2;
                 }
             }
             songItemContextMenuItem = new ContextMenuItem("Remove from Queue");
@@ -669,7 +671,7 @@ package menu
                 if (!song["access"] || song["access"] == GlobalVariables.SONG_ACCESS_PLAYABLE)
                 {
                     sI = new SongItem(song, _gvars.activeUser.getLevelRank(song), options.activeIndex == sX);
-                    songItemContextMenu.customItems[2].visible = isQueuePlaylist;
+                    songItemContextMenu.customItems[removeFromQueueCMItemIndex].visible = isQueuePlaylist;
                     (sI as SongItem).contextMenu = songItemContextMenu;
                     sI.y = yOffset;
                     sI.genre = -1;


### PR DESCRIPTION
Resolves #11.

An additional option has been added to the context menu that is used to remove songs from the current queue and becomes visible only when you're right-clicking songs in the current queue. Apart from that, a global variable has been added to keep track of whether you're looking at the current queue playlist.

Without this variable, when you switch to any tab other than the queue tab and right-click a song in the current queue, the extra option does not appear. Also, when you remove a song from the current queue, a number of factors might prevent the playlist from being refreshed visually. This variable helps immediately refresh the playlist to reflect the changed current queue.

I have tried to add the 'remove' button proposed by @TCHalogen, but I could not manage to get it working, so I've resorted to adding an option in the song item context menu instead.