### PR TITLE
Fix for multiplayer room join bug

### DIFF
--- a/src/com/flashfla/net/Multiplayer.as
+++ b/src/com/flashfla/net/Multiplayer.as
@@ -1079,6 +1079,7 @@ package com.flashfla.net {
 			}
 			updateRoom(event.params.roomId);
 			room.isJoined = false;
+			currentUser.room = null;
 			eventRoomLeft(room);
 		}
 


### PR DESCRIPTION
Caused by the user's room not being emptied when the onRoomLeft event function was triggered. Resolves #32