### PR TITLE
Flip result graph when switching graph type

### DIFF
--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -123,7 +123,6 @@ package game
 
             // Get Graph Type
             graphType = LocalStore.getVariable("result_graph_type", 0);
-            flipGraph = LocalStore.getVariable("result_flip_graph", false);
 
             // Text Style
             TEXT_STYLE = new StyleSheet();
@@ -518,6 +517,7 @@ package game
             graphDraw.graphics.clear();
 
             var graph_type:int = graphType;
+            flipGraph = LocalStore.getVariable("result_flip_graph", false);
 
             // Get Result
             if (result == null && songResults[resultIndex] != null)


### PR DESCRIPTION
For reasons unknown, after playing a song, the result graph doesn't get flipped when you toggle the checkbox for the graph flipping option and change the result graph type again. This is now fixed.

**Edit**: I now see why. After my PR for this feature request was closed, I made a few changes to the code that introduced this problem lol.