### PR TITLE
Add Additional Combo Color Options

### DIFF
--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -503,8 +503,14 @@ package classes
                 this.activeVisualMods = _settings.visual;
             if (_settings.judgeColours != null)
                 this.judgeColours = _settings.judgeColours;
-            if (_settings.comboColours != null)
-                this.comboColours = _settings.comboColours;
+            if(_settings.comboColours != null)
+            {
+                var comboColorCount:int = Math.min(this.comboColours.length, _settings.comboColours.length);
+                for(var i:int=0; i < comboColorCount; i++)
+                {
+                    this.comboColours[i] = _settings.comboColours[i];
+                }
+            }
             if (_settings.gameColours != null)
                 this.gameColours = _settings.gameColours;
             if (_settings.noteColours != null)

--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -92,7 +92,7 @@ package classes
         public var DISPLAY_MP_MASK:Boolean = false;
         public var DISPLAY_MP_TIMESTAMP:Boolean = false;
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200];
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteColours:Object = ["red", "blue", "purple", "yellow", "pink", "orange", "cyan", "green", "white"];
 

--- a/src/game/GameOptions.as
+++ b/src/game/GameOptions.as
@@ -45,7 +45,7 @@ package game
         public var displayMPCombo:Boolean = true;
 
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200];
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteDirections:Array = ["D", "L", "U", "R"];
         public var noteColors:Array = ["red", "blue", "purple", "yellow", "pink", "orange", "cyan", "green", "white"];

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -2193,7 +2193,7 @@ package game
                 score.update(gameScore);
 
             if (combo)
-                combo.update(hitCombo, hitAmazing, hitPerfect, hitGood, hitAverage, hitMiss, hitBoo);
+                combo.update(hitCombo, hitAmazing, hitPerfect, hitGood, hitAverage, hitMiss, hitBoo, gameRawGoods);
         }
 
         private var previousDiffs:Array = new Array();

--- a/src/game/controls/Combo.as
+++ b/src/game/controls/Combo.as
@@ -66,19 +66,50 @@ package game.controls
             field.text = combo.toString();
             fieldShadow.text = combo.toString();
 
+            /* colors[i]:
+               [0] = Normal,
+               [1] = FC,
+               [2] = AAA,
+               [3] = SDG,
+               [4] = BlackFlag,
+               [5] = AvFlag,
+               [6] = BooFlag
+             */
+
             if (options && (!options.isAutoplay || options.isEditor || options.multiplayer))
             {
-                if (miss)
+                if (miss) // Display blue combo text if miss has occurred
                 {
                     field.textColor = colors[0];
                     fieldShadow.textColor = darkcolors[0];
                 }
-                else if (good + average + boo == 0)
+                else if (good + average + boo == 0) // Display AAA color
                 {
                     field.textColor = colors[2];
                     fieldShadow.textColor = darkcolors[2];
                 }
-                else
+                else if (good == 1 && average + boo == 0) // Display BlackFlag color
+                {
+                    field.textColor = colors[4];
+                    fieldShadow.textColor = darkcolors[4];
+                }
+                else if (average == 1 && good + boo == 0) // Display AvFlag color
+                {
+                    field.textColor = colors[5];
+                    fieldShadow.textColor = darkcolors[5];
+                }
+                else if (boo == 1 && good + average == 0) // Display BooFlag color
+                {
+                    field.textColor = colors[6];
+                    fieldShadow.textColor = darkcolors[6];
+                }
+                // !! gameRawGoods variable throwing warning but is functioning as expected
+                else if (gameRawGoods < 10) // Display SDG color if raw goods < 10
+                {
+                    field.textColor = colors[3];
+                    fieldShadow.textColor = darkcolors[3];
+                }
+                else // Display green for FC
                 {
                     field.textColor = colors[1];
                     fieldShadow.textColor = darkcolors[1];

--- a/src/game/controls/Combo.as
+++ b/src/game/controls/Combo.as
@@ -61,7 +61,7 @@ package game.controls
             }
         }
 
-        public function update(combo:int, amazing:int = 0, perfect:int = 0, good:int = 0, average:int = 0, miss:int = 0, boo:int = 0):void
+        public function update(combo:int, amazing:int = 0, perfect:int = 0, good:int = 0, average:int = 0, miss:int = 0, boo:int = 0, raw_goods:Number = 0):void
         {
             field.text = combo.toString();
             fieldShadow.text = combo.toString();
@@ -103,8 +103,7 @@ package game.controls
                     field.textColor = colors[6];
                     fieldShadow.textColor = darkcolors[6];
                 }
-                // !! gameRawGoods variable throwing warning but is functioning as expected
-                else if (gameRawGoods < 10) // Display SDG color if raw goods < 10
+                else if (raw_goods < 10) // Display SDG color if raw goods < 10
                 {
                     field.textColor = colors[3];
                     fieldShadow.textColor = darkcolors[3];

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -2040,22 +2040,10 @@ package popups
                     optionJudgeColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.judgeColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
                     optionJudgeColors[i]["display"].color = _gvars.activeUser.judgeColours[i];
                 }
-                // Set Combo Colors -- if User data has values to match all fields, use them - otherwise use default values. This prevents crash when user data array doesn't contain correct # of values
-                if (_gvars.activeUser.comboColours.length == DEFAULT_OPTIONS.comboColours.length)
+                for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
                 {
-                    for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
-                    {
-                        optionComboColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.comboColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
-                        optionComboColors[i]["display"].color = _gvars.activeUser.comboColours[i];
-                    }
-                }
-                else
-                {
-                    for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
-                    {
-                        optionComboColors[i]["text"].text = "#" + StringUtil.pad(DEFAULT_OPTIONS.comboColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
-                        optionComboColors[i]["display"].color = DEFAULT_OPTIONS.comboColours[i];
-                    }
+                    optionComboColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.comboColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
+                    optionComboColors[i]["display"].color = _gvars.activeUser.comboColours[i];
                 }
                 for (i = 0; i < DEFAULT_OPTIONS.gameColours.length; i++)
                 {

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -918,56 +918,6 @@ package popups
 
                 yOff += 25;
 
-                var gameComboColorTitle:Text = new Text(_lang.string("options_combo_colors_title"));
-                gameComboColorTitle.x = xOff + 5;
-                gameComboColorTitle.y = yOff;
-                gameComboColorTitle.width = 211;
-                gameComboColorTitle.align = Text.CENTER;
-                box.addChild(gameComboColorTitle);
-                yOff += 24;
-
-                optionComboColors = [];
-                for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
-                {
-                    var gameComboColor:Text = new Text(_lang.string("options_combo_colors_" + i));
-                    gameComboColor.x = xOff;
-                    gameComboColor.y = yOff;
-                    gameComboColor.width = 70;
-                    gameComboColor.align = Text.RIGHT;
-                    box.addChild(gameComboColor);
-
-                    var optionComboColor:BoxText = new BoxText(70, 20);
-                    optionComboColor.x = xOff + 75;
-                    optionComboColor.y = yOff;
-                    optionComboColor.combo_color_id = i;
-                    optionComboColor.restrict = "#0-9a-f";
-                    optionComboColor.field.maxChars = 7;
-                    optionComboColor.addEventListener(Event.CHANGE, changeHandler);
-                    box.addChild(optionComboColor);
-
-                    var gameComboColorDisplay:ColorField = new ColorField(0, 45, 20);
-                    gameComboColorDisplay.x = xOff + 150;
-                    gameComboColorDisplay.y = yOff;
-                    gameComboColorDisplay.key_name = "gameComboColorDisplay";
-                    gameComboColorDisplay.addEventListener(Event.CHANGE, changeHandler);
-                    box.addChild(gameComboColorDisplay);
-
-                    var optionComboColorReset:BoxButton = new BoxButton(20, 20, "R");
-                    optionComboColorReset.x = xOff + 200;
-                    optionComboColorReset.y = yOff;
-                    optionComboColorReset.combo_color_reset_id = i;
-                    optionComboColorReset.boxColor = 0xff0000;
-                    optionComboColorReset.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
-                    box.addChild(optionComboColorReset);
-                    optionComboColors.push({"text": optionComboColor, "display": gameComboColorDisplay, "reset": optionComboColorReset});
-
-                    yOff += 25;
-                }
-
-                ///- Col 2
-                xOff += 245;
-                yOff = BASE_Y_POSITION;
-
                 var gameGameColorTitle:Text = new Text(_lang.string("options_game_colors_title"));
                 gameGameColorTitle.x = xOff + 5;
                 gameGameColorTitle.y = yOff;
@@ -1012,6 +962,56 @@ package popups
                     optionGameColorReset.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                     box.addChild(optionGameColorReset);
                     optionGameColors.push({"text": optionGameColor, "display": gameGameColorDisplay, "reset": optionGameColorReset});
+
+                    yOff += 25;
+                }
+
+                ///- Col 2
+                xOff += 245;
+                yOff = BASE_Y_POSITION;
+
+                var gameComboColorTitle:Text = new Text(_lang.string("options_combo_colors_title"));
+                gameComboColorTitle.x = xOff + 5;
+                gameComboColorTitle.y = yOff;
+                gameComboColorTitle.width = 211;
+                gameComboColorTitle.align = Text.CENTER;
+                box.addChild(gameComboColorTitle);
+                yOff += 24;
+
+                optionComboColors = [];
+                for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
+                {
+                    var gameComboColor:Text = new Text(_lang.string("options_combo_colors_" + i));
+                    gameComboColor.x = xOff;
+                    gameComboColor.y = yOff;
+                    gameComboColor.width = 70;
+                    gameComboColor.align = Text.RIGHT;
+                    box.addChild(gameComboColor);
+
+                    var optionComboColor:BoxText = new BoxText(70, 20);
+                    optionComboColor.x = xOff + 75;
+                    optionComboColor.y = yOff;
+                    optionComboColor.combo_color_id = i;
+                    optionComboColor.restrict = "#0-9a-f";
+                    optionComboColor.field.maxChars = 7;
+                    optionComboColor.addEventListener(Event.CHANGE, changeHandler);
+                    box.addChild(optionComboColor);
+
+                    var gameComboColorDisplay:ColorField = new ColorField(0, 45, 20);
+                    gameComboColorDisplay.x = xOff + 150;
+                    gameComboColorDisplay.y = yOff;
+                    gameComboColorDisplay.key_name = "gameComboColorDisplay";
+                    gameComboColorDisplay.addEventListener(Event.CHANGE, changeHandler);
+                    box.addChild(gameComboColorDisplay);
+
+                    var optionComboColorReset:BoxButton = new BoxButton(20, 20, "R");
+                    optionComboColorReset.x = xOff + 200;
+                    optionComboColorReset.y = yOff;
+                    optionComboColorReset.combo_color_reset_id = i;
+                    optionComboColorReset.boxColor = 0xff0000;
+                    optionComboColorReset.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
+                    box.addChild(optionComboColorReset);
+                    optionComboColors.push({"text": optionComboColor, "display": gameComboColorDisplay, "reset": optionComboColorReset});
 
                     yOff += 25;
                 }
@@ -2040,10 +2040,22 @@ package popups
                     optionJudgeColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.judgeColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
                     optionJudgeColors[i]["display"].color = _gvars.activeUser.judgeColours[i];
                 }
-                for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
+                // Set Combo Colors -- if User data has values to match all fields, use them - otherwise use default values. This prevents crash when user data array doesn't contain correct # of values
+                if (_gvars.activeUser.comboColours.length == DEFAULT_OPTIONS.comboColours.length)
                 {
-                    optionComboColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.comboColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
-                    optionComboColors[i]["display"].color = _gvars.activeUser.comboColours[i];
+                    for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
+                    {
+                        optionComboColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.comboColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
+                        optionComboColors[i]["display"].color = _gvars.activeUser.comboColours[i];
+                    }
+                }
+                else
+                {
+                    for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
+                    {
+                        optionComboColors[i]["text"].text = "#" + StringUtil.pad(DEFAULT_OPTIONS.comboColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
+                        optionComboColors[i]["display"].color = DEFAULT_OPTIONS.comboColours[i];
+                    }
                 }
                 for (i = 0; i < DEFAULT_OPTIONS.gameColours.length; i++)
                 {


### PR DESCRIPTION
Change gives additional combo color functionality and options to set those.

Changes:
Updated comboColour array (User.as)
Updated comboColour array defaults (GameOptions.as)
Updated combo color logic (Combo.as); also includes update to GamePlay.as to pass gameRawGoods var to Combo.as
Updated settings menu to swap columns for game color & combo color to better fit new options (PopupOptions.as)
Added a check to merge existing comboColors with system default if sizes of arrays were different to prevent crash (User.as)

![image](https://user-images.githubusercontent.com/2185274/85451155-8ec8ba80-b567-11ea-91e1-c014d1005b62.png)

Remaining updates:
1. Add "options_combo_colors_3" through "options_combo_colors_6" to language editor files
a. SDG
b. Black Flag
c. Average Flag
d. Boo Flag