### PR TITLE
Prevent logging in with wrong user credentials

### DIFF
--- a/src/LoginMenu.as
+++ b/src/LoginMenu.as
@@ -323,7 +323,7 @@ package
                 _gvars.gameMain.addAlert(_lang.string("login_invalid_session"));
                 changeUserEvent(e);
             }
-            else if (_data.result >= 1 || _data.result <= 3)
+            else if (_data.result >= 1 && _data.result <= 3)
             {
                 if (_data.result == 1 || _data.result == 2)
                     saveLoginDetails(this.rememberPassword, _data.session);


### PR DESCRIPTION
When a user submits a wrong username and password combo in the login menu, the `result` parameter returned would be 0. However, there is a bug in the logic that prevents blocking the faulty login, and instead proceeds with loading user details, which would lead to an error that reads `Error #2044: Unhandled IOErrorEvent:. text=Error #2124: Loaded file is an unknown type.`

The correct behaviour after entering wrong credentials is to empty the password box and highlight it in red.