### PR TITLE
Enable/Disable + Fixes for Combo Color Options

### DIFF
--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -92,7 +92,8 @@ package classes
         public var DISPLAY_MP_MASK:Boolean = false;
         public var DISPLAY_MP_TIMESTAMP:Boolean = false;
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag
+        public var enableComboColors:Array = [true, true, true, false, false, false, false, false];
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteColours:Object = ["red", "blue", "purple", "yellow", "pink", "orange", "cyan", "green", "white"];
 
@@ -503,12 +504,19 @@ package classes
                 this.activeVisualMods = _settings.visual;
             if (_settings.judgeColours != null)
                 this.judgeColours = _settings.judgeColours;
-            if(_settings.comboColours != null)
+            if (_settings.comboColours != null)
             {
                 var comboColorCount:int = Math.min(this.comboColours.length, _settings.comboColours.length);
-                for(var i:int=0; i < comboColorCount; i++)
+                for (var i:int = 0; i < comboColorCount; i++)
                 {
                     this.comboColours[i] = _settings.comboColours[i];
+                }
+            }
+            if (_settings.enableComboColors != null)
+            {
+                for (i = 0; i < enableComboColors.length; i++)
+                {
+                    this.enableComboColors[i] = _settings.enableComboColors[i];
                 }
             }
             if (_settings.gameColours != null)
@@ -596,6 +604,7 @@ package classes
             gameSave.visual = this.activeVisualMods;
             gameSave.judgeColours = this.judgeColours;
             gameSave.comboColours = this.comboColours;
+            gameSave.enableComboColors = this.enableComboColors;
             gameSave.gameColours = this.gameColours;
             gameSave.noteColours = this.noteColours;
             gameSave.songQueues = this.songQueues;

--- a/src/game/GameOptions.as
+++ b/src/game/GameOptions.as
@@ -45,7 +45,8 @@ package game
         public var displayMPCombo:Boolean = true;
 
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag
+        public var enableComboColors:Array = [true, true, true, false, false, false, false, false];
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteDirections:Array = ["D", "L", "U", "R"];
         public var noteColors:Array = ["red", "blue", "purple", "yellow", "pink", "orange", "cyan", "green", "white"];
@@ -113,6 +114,7 @@ package game
 
             judgeColours = user.judgeColours.concat();
             comboColours = user.comboColours.concat();
+            enableComboColors = user.enableComboColors.concat();
             gameColours = user.gameColours.concat();
 
             for (var i:int = 0; i < noteColors.length; i++)

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -620,7 +620,7 @@ package game
                 gameFirstNoteFrame = song.getNote(0).frame;
             }
             if (comboTotal)
-                comboTotal.update(song.totalNotes);
+                comboTotal.update(song.totalNotes, _gvars.activeUser.enableComboColors);
 
             msStartTime = getTimer();
             absoluteStart = getTimer();
@@ -2156,7 +2156,7 @@ package game
                 score.update(gameScore);
 
             if (combo)
-                combo.update(hitCombo, hitAmazing, hitPerfect, hitGood, hitAverage, hitMiss, hitBoo, gameRawGoods);
+                combo.update(hitCombo, _gvars.activeUser.enableComboColors, hitAmazing, hitPerfect, hitGood, hitAverage, hitMiss, hitBoo, gameRawGoods);
         }
 
         private var previousDiffs:Array = new Array();

--- a/src/game/controls/Combo.as
+++ b/src/game/controls/Combo.as
@@ -61,7 +61,7 @@ package game.controls
             }
         }
 
-        public function update(combo:int, amazing:int = 0, perfect:int = 0, good:int = 0, average:int = 0, miss:int = 0, boo:int = 0, raw_goods:Number = 0):void
+        public function update(combo:int, userComboOptions:Array, amazing:int = 0, perfect:int = 0, good:int = 0, average:int = 0, miss:int = 0, boo:int = 0, raw_goods:Number = 0):void
         {
             field.text = combo.toString();
             fieldShadow.text = combo.toString();
@@ -71,47 +71,53 @@ package game.controls
                [1] = FC,
                [2] = AAA,
                [3] = SDG,
-               [4] = BlackFlag,
-               [5] = AvFlag,
-               [6] = BooFlag
+               [4] = Black Flag,
+               [5] = Average Flag,
+               [6] = Boo Flag,
+               [7] = Miss Flag
              */
 
             if (options && (!options.isAutoplay || options.isEditor || options.multiplayer))
             {
-                if (miss) // Display blue combo text if miss has occurred
-                {
-                    field.textColor = colors[0];
-                    fieldShadow.textColor = darkcolors[0];
-                }
-                else if (good + average + boo == 0) // Display AAA color
+                if (userComboOptions[2] && good + average + boo + miss == 0) // Display AAA color
                 {
                     field.textColor = colors[2];
                     fieldShadow.textColor = darkcolors[2];
                 }
-                else if (good == 1 && average + boo == 0) // Display BlackFlag color
+                else if (userComboOptions[4] && good == 1 && average + boo + miss == 0) // Display Black Flag color
                 {
                     field.textColor = colors[4];
                     fieldShadow.textColor = darkcolors[4];
                 }
-                else if (average == 1 && good + boo == 0) // Display AvFlag color
+                else if (userComboOptions[5] && average == 1 && good + boo + miss == 0) // Display Average Flag color
                 {
                     field.textColor = colors[5];
                     fieldShadow.textColor = darkcolors[5];
                 }
-                else if (boo == 1 && good + average == 0) // Display BooFlag color
+                else if (userComboOptions[6] && boo == 1 && good + average + miss == 0) // Display Boo Flag color
                 {
                     field.textColor = colors[6];
                     fieldShadow.textColor = darkcolors[6];
                 }
-                else if (raw_goods < 10) // Display SDG color if raw goods < 10
+                else if (userComboOptions[7] && miss == 1 && good + average + boo == 0) // Display Miss Flag color
+                {
+                    field.textColor = colors[7];
+                    fieldShadow.textColor = darkcolors[7];
+                }
+                else if (userComboOptions[3] && raw_goods < 10) // Display SDG color if raw goods < 10
                 {
                     field.textColor = colors[3];
                     fieldShadow.textColor = darkcolors[3];
                 }
-                else // Display green for FC
+                else if (userComboOptions[1] && miss == 0) // Display green for FC
                 {
                     field.textColor = colors[1];
                     fieldShadow.textColor = darkcolors[1];
+                }
+                else // Display blue combo text
+                {
+                    field.textColor = colors[0];
+                    fieldShadow.textColor = darkcolors[0];
                 }
             }
         }

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -47,6 +47,7 @@ package popups
     import menu.MenuSongSelection;
     import com.flashfla.utils.sprintf;
 
+
     public class PopupOptions extends MenuPanel
     {
         private const TAB_MAIN:int = 0;
@@ -123,6 +124,7 @@ package popups
 
         private var optionJudgeColors:Array;
         private var optionComboColors:Array;
+        private var optionComboColorCheck:checkBox;
         private var optionGameColors:Array;
         private var optionNoteColors:Array;
 
@@ -982,7 +984,18 @@ package popups
                     optionComboColorReset.boxColor = 0xff0000;
                     optionComboColorReset.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                     box.addChild(optionComboColorReset);
-                    optionComboColors.push({"text": optionComboColor, "display": gameComboColorDisplay, "reset": optionComboColorReset});
+
+                    if (i > 0)
+                    {
+                        optionComboColorCheck = new checkBox();
+                        optionComboColorCheck.x = xOff + 225;
+                        optionComboColorCheck.y = yOff + 3;
+                        optionComboColorCheck.combo_color_enable_id = i;
+                        optionComboColorCheck.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
+                        box.addChild(optionComboColorCheck);
+                    }
+
+                    optionComboColors.push({"text": optionComboColor, "display": gameComboColorDisplay, "reset": optionComboColorReset, "enable": optionComboColorCheck});
 
                     yOff += 25;
                 }
@@ -1657,6 +1670,12 @@ package popups
                 _gvars.activeUser.comboColours[e.target.combo_color_reset_id] = DEFAULT_OPTIONS.comboColours[e.target.combo_color_reset_id];
             }
 
+            // Combo Color Enable/Disable
+            else if (e.target.hasOwnProperty("combo_color_enable_id"))
+            {
+                _gvars.activeUser.enableComboColors[e.target.combo_color_enable_id] = !_gvars.activeUser.enableComboColors[e.target.combo_color_enable_id];
+            }
+
             // Game Background Color Reset
             else if (e.target.hasOwnProperty("game_color_reset_id"))
             {
@@ -2041,11 +2060,17 @@ package popups
                     optionJudgeColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.judgeColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
                     optionJudgeColors[i]["display"].color = _gvars.activeUser.judgeColours[i];
                 }
+                // Set Combo Colors
                 for (i = 0; i < DEFAULT_OPTIONS.comboColours.length; i++)
                 {
                     optionComboColors[i]["text"].text = "#" + StringUtil.pad(_gvars.activeUser.comboColours[i].toString(16).substr(0, 6), 6, "0", StringUtil.STR_PAD_LEFT);
                     optionComboColors[i]["display"].color = _gvars.activeUser.comboColours[i];
+                    if (i > 0)
+                    {
+                        optionComboColors[i]["enable"].gotoAndStop(_gvars.activeUser.enableComboColors[i] ? 2 : 1);
+                    }
                 }
+                // Set Game Colors
                 for (i = 0; i < DEFAULT_OPTIONS.gameColours.length; i++)
                 {
                     if (i == 2 || i == 3)


### PR DESCRIPTION
Added additional functionality (enable/disable) and fixes for Combo Color options.

Options can now be enabled/disabled individually, and are reset correctly when the "Reset" menu option is used.

![image](https://user-images.githubusercontent.com/2185274/86040278-c0330180-ba11-11ea-977d-1cc051f8232f.png)
