### PR TITLE
Song selection menu improvements

### DIFF
--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -12,6 +12,7 @@ package menu
     import classes.*;
     import classes.chart.Song;
     import com.bit101.components.ComboBox;
+    import com.bit101.components.PushButton;
     import com.flashfla.components.*;
     import com.flashfla.utils.ArrayUtil;
     import com.flashfla.utils.NumberUtil;
@@ -1415,31 +1416,42 @@ package menu
             var newIndex:int = options.activeIndex;
             var lastIndex:int = options.activeIndex;
             var isNavDirectionUp:Boolean = true;
+            var maxGenreIndex:int;
+            if (GENRE_MODE == GENRE_DIFFICULTIES)
+            {
+                maxGenreIndex = _gvars.DIFFICULTY_RANGES.length - 1;
+            }
+            else if (GENRE_MODE == GENRE_SONGFLAGS)
+            {
+                maxGenreIndex = GlobalVariables.SONG_ICON_TEXT.length - 1;
+            }
+            else
+            {
+                maxGenreIndex = (!_gvars.activeUser.DISPLAY_LEGACY_SONGS && !_playlist.engine) ? _gvars.TOTAL_GENRES - 2 : _gvars.TOTAL_GENRES - 1;
+            }
+
+            if (options.activeIndex == -1)
+            {
+                newIndex = lastIndex = 0;
+            }
+
             switch (e.keyCode)
             {
                 case Keyboard.PAGE_UP:
                     newIndex -= 11;
-                    if (newIndex < 0)
-                        newIndex = 0;
                     break;
 
                 case Keyboard.UP:
                     newIndex -= 1;
-                    if (newIndex < 0)
-                        newIndex = 0;
                     break;
 
                 case Keyboard.PAGE_DOWN:
                     newIndex += 11;
-                    if (newIndex > genreLength - 1)
-                        newIndex = genreLength - 1;
                     isNavDirectionUp = false;
                     break;
 
                 case Keyboard.DOWN:
                     newIndex += 1;
-                    if (newIndex > genreLength - 1)
-                        newIndex = genreLength - 1;
                     isNavDirectionUp = false;
                     break;
 
@@ -1447,8 +1459,8 @@ package menu
                     options.activeGenre = options.activeGenre + (e.ctrlKey ? -1 : 1);
                     options.activeIndex = -1;
                     if (options.activeGenre < -1)
-                        options.activeGenre = _gvars.TOTAL_GENRES - 1;
-                    if (options.activeGenre > _gvars.TOTAL_GENRES - 1)
+                        options.activeGenre = maxGenreIndex;
+                    if (options.activeGenre > maxGenreIndex)
                         options.activeGenre = -1;
                     isQueuePlaylist = false;
                     buildGenreList();
@@ -1458,7 +1470,7 @@ package menu
 
                 case Keyboard.ENTER:
                 case Keyboard.SPACE:
-                    if (stage.focus == stage && options.activeSongID >= 0)
+                    if (!(stage.focus is PushButton) && options.activeSongID >= 0)
                     {
                         if (_mp.gameplayHasOpponent())
                             multiplayerLoad();
@@ -1468,13 +1480,33 @@ package menu
                     return;
 
                 default:
-                    if (stage.focus == stage && ((e.keyCode >= 48 && e.keyCode <= 111) || (e.keyCode >= 186 && e.keyCode <= 222)))
+                    if (!(stage.focus is PushButton) && ((e.keyCode >= 48 && e.keyCode <= 111) || (e.keyCode >= 186 && e.keyCode <= 222)))
                     {
                         // Focus on search and begin typing.
-                        options.infoTab = options.infoTab == TAB_SEARCH ? TAB_PLAYLIST : TAB_SEARCH;
-                        buildInfoTab();
-                        searchBox.text = ""; // Empty the box if resetting.
+                        if (options.infoTab != TAB_SEARCH)
+                        {
+                            options.infoTab = TAB_SEARCH;
+                            buildInfoTab();
+                            searchBox.text = ""; // Empty the box if resetting.
+                        }
+                        else
+                        {
+                            buildInfoTab();
+                        }
                     }
+                    return;
+            }
+
+            if (genreLength == 0)
+                return;
+
+            if (newIndex < 0)
+            {
+                newIndex = 0;
+            }
+            else if (newIndex > genreLength - 1)
+            {
+                newIndex = genreLength - 1;
             }
 
             if (newIndex != lastIndex)

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -1151,6 +1151,7 @@ package menu
         {
             if (e.target == genre_mode_prev || e.target == genre_mode_next)
             {
+                clearSearchStateParams();
                 GENRE_MODE = (GENRE_MODE + (e.target == genre_mode_prev ? -1 : 1));
                 if (GENRE_MODE < 0)
                     GENRE_MODE = GENRE_MODES;
@@ -1169,6 +1170,7 @@ package menu
                 var clickAction:String = e.target.action;
                 if (clickAction == "search")
                 {
+                    clearSearchStateParams();
                     options.infoTab = options.infoTab == TAB_SEARCH ? TAB_PLAYLIST : TAB_SEARCH;
                     _gvars.tempFlags['active_tab_temp'] = options.infoTab;
                     buildInfoTab();
@@ -1456,6 +1458,7 @@ package menu
                     break;
 
                 case Keyboard.TAB:
+                    clearSearchStateParams();
                     options.activeGenre = options.activeGenre + (e.ctrlKey ? -1 : 1);
                     options.activeIndex = -1;
                     if (options.activeGenre < -1)
@@ -1480,19 +1483,19 @@ package menu
                     return;
 
                 default:
-                    if (!(stage.focus is PushButton) && ((e.keyCode >= 48 && e.keyCode <= 111) || (e.keyCode >= 186 && e.keyCode <= 222)))
+                    if (!(stage.focus is PushButton) && ((e.keyCode == Keyboard.BACKSPACE) || (e.keyCode >= 48 && e.keyCode <= 111) || (e.keyCode >= 186 && e.keyCode <= 222)))
                     {
+                        // Store the string from the searchbox.
+                        var tempSearchBoxString:String = "";
+                        if (searchBox != null)
+                        {
+                            tempSearchBoxString = searchBox.text;
+                        }
+
                         // Focus on search and begin typing.
-                        if (options.infoTab != TAB_SEARCH)
-                        {
-                            options.infoTab = TAB_SEARCH;
-                            buildInfoTab();
-                            searchBox.text = ""; // Empty the box if resetting.
-                        }
-                        else
-                        {
-                            buildInfoTab();
-                        }
+                        options.infoTab = TAB_SEARCH;
+                        buildInfoTab();
+                        searchBox.text = tempSearchBoxString; // Restore the string.
                     }
                     return;
             }

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -1472,7 +1472,6 @@ package menu
                     return;
 
                 case Keyboard.ENTER:
-                case Keyboard.SPACE:
                     if (!(stage.focus is PushButton) && options.activeSongID >= 0)
                     {
                         if (_mp.gameplayHasOpponent())
@@ -1483,7 +1482,7 @@ package menu
                     return;
 
                 default:
-                    if (!(stage.focus is PushButton) && ((e.keyCode == Keyboard.BACKSPACE) || (e.keyCode >= 48 && e.keyCode <= 111) || (e.keyCode >= 186 && e.keyCode <= 222)))
+                    if (!(stage.focus is PushButton) && ((e.keyCode == Keyboard.BACKSPACE) || (e.keyCode == Keyboard.SPACE) || (e.keyCode >= 48 && e.keyCode <= 111) || (e.keyCode >= 186 && e.keyCode <= 222)))
                     {
                         // Store the string from the searchbox.
                         var tempSearchBoxString:String = "";


### PR DESCRIPTION
Bugs fixed:
- When pressing TAB or Ctrl+TAB to navigate through genre list entries, if the song flags genre list is being displayed, you could access it out-of-bounds, as the maximum genre index being used to update the currenty active genre entry is wrong. This index is now assigned a value based on the length of the genre list displayed.
- When there is no playlist and the up or down navigation keys are pressed, the `songItems` array is accessed out-of-bounds. An additional check has been put in place so that navigation would not be done if the playlist is empty.
- For cases where `options.activeIndex` is `-1`, you would have to press the down arrow key twice to navigate to the second playlist entry. In this case, we assume the active index to be `0` (i.e. the first playlist entry). A check has been added to assign `newIndex` and `lastIndex` a value of `0` when `options.activeIndex == -1` to make song navigation work properly.

Improvements:
- When pressing ENTER to play a song or typing something on the keyboard to type stuff into the searchbox while not being focused on it, a check is done to see whether `stage.focus == stage`. However, the stage focus could be nothing, a song item, the stage itself, the scrollbar, or a button from the combo box. For the first 4 cases, we would expect the action the keys do to be executed. For the last case, we wouldn't expect anything to happen. The `stage.focus` check is modified for these use cases.
- When the search tab is being shown, the searchbox is not being focused and keys are pressed, the info tab would switch to displaying the playlist tab. On the playlist tab, typing something would switch back to the search tab. While on the search tab, we would expect to be able to continue typing in the searchbox even if we're not focused onto it instead of switching to another tab. The code is modified for this use case.
- The searchbox text is resetted if you're typing in an info tab that isn't the search tab (e.g. the queue tab). Instead of resetting it, the searchbox text is now saved between searches.
- A few other minor issues cause the searchbox to display the saved search string in `_gvars.tempFlags['active_search_temp']`, which leads to several inconsistencies when moving around the menu between searches. This is fixed too.
- Backspace support has been added: You can now press the backspace key to remove text from the searchbox while not being focused on it.

Functionality changes:
- Originally, you could press SPACE to play songs. As some users might want to search for songs with names containing spaces, the SPACE key has been repurposed to type stuff into the searchbox. It no longer plays songs.