### PR TITLE
Fix receptor layer position.

### DIFF
--- a/src/game/controls/NoteBox.as
+++ b/src/game/controls/NoteBox.as
@@ -90,10 +90,10 @@ package game.controls
             rightReceptor = _noteskins.getReceptor(options.noteskin, "R");
             rightReceptor.KEY = "Right";
 
-            addChild(leftReceptor);
-            addChild(downReceptor);
-            addChild(upReceptor);
-            addChild(rightReceptor);
+            addChildAt(leftReceptor, 0);
+            addChildAt(downReceptor, 0);
+            addChildAt(upReceptor, 0);
+            addChildAt(rightReceptor, 0);
 
             // Other Stuff
             sideScroll = options.scrollDirection == "left" || options.scrollDirection == "right";


### PR DESCRIPTION
This forces the receptor to always be the lowest layer in the NoteBox, behind all receptors.