### PR TITLE
Refactor takeScreenShot

### DIFF
--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -510,23 +510,20 @@ package
         /**
          * Takes a screenshot of the stage and saves it to disk.
          */
-        public function takeScreenShot(params:Object):void
+        public function takeScreenShot(filename:String = null):void
         {
             // Create Bitmap of Stage
             var b:BitmapData = new BitmapData(Main.GAME_WIDTH, Main.GAME_HEIGHT, false, 0x000000);
             b.draw(gameMain.stage);
 
-            if (params.o == false)
+            try
             {
-                try
-                {
-                    var _file:FileReference = new FileReference();
-                    _file.save(PNGEncoder.encode(b), AirContext.createFileName((params["text"] != null ? params["text"] : "R^3 - " + DateUtil.toRFC822(new Date()).replace(/:/g, ".")) + ".png"));
-                }
-                catch (e:Error)
-                {
-                    gameMain.addAlert("ERROR: Unable to save image.", 120);
-                }
+                var _file:FileReference = new FileReference();
+                _file.save(PNGEncoder.encode(b), AirContext.createFileName((filename != null ? filename : "R^3 - " + DateUtil.toRFC822(new Date()).replace(/:/g, ".")) + ".png"));
+            }
+            catch (e:Error)
+            {
+                gameMain.addAlert("ERROR: Unable to save image.", 120);
             }
         }
 

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -1357,7 +1357,7 @@ package game
 
                     ext = "R^3 - " + grS.name + rateString + " - " + gRP.score + " - " + (gRP.perfect + gRP.amazing) + "-" + gRP.good + "-" + gRP.average + "-" + gRP.miss + "-" + gRP.boo;
                 }
-                _gvars.takeScreenShot({o: false, s: 1, text: ext});
+                _gvars.takeScreenShot(ext);
             }
             else if (target == navPrev && navPrev.visible)
             {

--- a/src/popups/PopupContextMenu.as
+++ b/src/popups/PopupContextMenu.as
@@ -132,7 +132,7 @@ package popups
             }
             else if (e.target.action == "screenshotLocal")
             {
-                _gvars.takeScreenShot({o: false, s: 1});
+                _gvars.takeScreenShot();
             }
             else if (e.target.action == "options")
             {


### PR DESCRIPTION
Originally, an object with 3 parameters (`o`, `s`, and `text`) is passed into the function. However, `o` is always false, and `s` is unused.
The function has been modified to accept only filenames.