### PR TITLE
Websocket Fixes and Optimizations

### DIFF
--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -118,6 +118,7 @@ package
         public var sql_db:File;
 
         private var websocket_server:AIRServer;
+        private static var websocket_message:Message = new Message();
 
         public function loadAirOptions():void
         {
@@ -217,10 +218,9 @@ package
         {
             if (websocket_server != null)
             {
-                var msg:Message = new Message();
-                msg.command = cmd;
-                msg.data = data;
-                websocket_server.sendMessageToAllClients(msg);
+                websocket_message.command = cmd;
+                websocket_message.data = data;
+                websocket_server.sendMessageToAllClients(websocket_message);
             }
         }
 

--- a/src/arc/NoteMod.as
+++ b/src/arc/NoteMod.as
@@ -204,5 +204,39 @@ package arc
             }
             return notes.length;
         }
+
+        public function transformSongLength():Number
+        {
+            if (notes.length <= 0)
+                return 0;
+
+            var firstNote:Note;
+            var lastNote:Note = notes[notes.length - 1];
+            var time:Number = lastNote.time;
+
+            if (modIsolation)
+            {
+
+                if (options.isolationLength > 0)
+                {
+                    firstNote = notes[Math.min(notes.length - 1, options.isolationOffset - 1)];
+                    lastNote = notes[Math.min(notes.length - 1, options.isolationOffset + options.isolationLength)];
+                    time = lastNote.time - firstNote.time;
+                }
+                else
+                {
+                    firstNote = notes[Math.min(notes.length - 1, options.isolationOffset - 1)];
+                    time = lastNote.time - firstNote.time;
+                }
+            }
+
+            // Rates after everything.
+            if (modRate)
+            {
+                time /= options.songRate;
+            }
+
+            return time + 1; // 1 seconds for fade out.
+        }
     }
 }

--- a/src/classes/chart/Song.as
+++ b/src/classes/chart/Song.as
@@ -634,6 +634,35 @@ package classes.chart
             return chart.Notes.length;
         }
 
+        public function get chartTime():Number
+        {
+            if (noteMod.required())
+            {
+                return noteMod.transformSongLength();
+            }
+
+            if (!chart.Notes)
+            {
+                return 0;
+            }
+
+            return getNote(totalNotes - 1).time + 1; // 1 second for fadeout.
+        }
+
+        public function get chartTimeFormatted():String
+        {
+            var totalSecs:int = chartTime;
+            var minutes:String = Math.floor(totalSecs / 60).toString();
+            var seconds:String = (totalSecs % 60).toString();
+
+            if (seconds.length == 1)
+            {
+                seconds = "0" + seconds;
+            }
+
+            return minutes + ":" + seconds;
+        }
+
         public function get noteSteps():int
         {
             return chart.framerate + 1;

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -166,7 +166,8 @@ package game
 
         private var GAME_STATE:uint = GAME_PLAY;
 
-        private var SOCKET_MESSAGE:Object = {};
+        private var SOCKET_SONG_MESSAGE:Object = {};
+        private var SOCKET_SCORE_MESSAGE:Object = {};
 
         public function GamePlay(myParent:MenuPanel)
         {
@@ -235,6 +236,7 @@ package game
             // Create Background
             initBackground();
             initPlayerVars();
+
             // Init Core
             initCore();
 
@@ -254,7 +256,7 @@ package game
             }
 
             // Prebuild Websocket Message, this is updated instead of creating a new object every message.
-            SOCKET_MESSAGE = {"player": {
+            SOCKET_SONG_MESSAGE = {"player": {
                         "settings": options.settingsEncode(),
                         "name": _gvars.activeUser.name,
                         "userid": _gvars.activeUser.id,
@@ -275,9 +277,6 @@ package game
                         "level": song.entry.level,
                         "difficulty": song.entry.difficulty,
                         "style": song.entry.style,
-                        "time": song.entry.time,
-                        "time_seconds": song.entry.timeSecs,
-                        "note_count": song.entry.arrows,
                         "author": song.entry.author,
                         "author_url": song.entry.author_url,
                         "stepauthor": song.entry.stepauthor,
@@ -286,22 +285,26 @@ package game
                         "nps_min": song.entry.min_nps,
                         "nps_max": song.entry.max_nps,
                         "release_date": song.entry.releasedate,
-                        "song_rating": song.entry.song_rating
+                        "song_rating": song.entry.song_rating,
+                        // Trust the chart, not the playlist.
+                        "time": song.chartTimeFormatted,
+                        "time_seconds": song.chartTime,
+                        "note_count": song.totalNotes,
+                        "nps_avg": (song.totalNotes / song.chartTime)
                     },
-                    "score": {
-                        "best_score": _gvars.activeUser.getLevelRank(song.entry),
-                        "amazing": 0,
-                        "perfect": 0,
-                        "good": 0,
-                        "average": 0,
-                        "miss": 0,
-                        "boo": 0,
-                        "score": 0,
-                        "combo": 0,
-                        "maxcombo": 0,
-                        "restarts": 0,
-                        "last_hit": null
-                    }};
+                    "best_score": _gvars.activeUser.getLevelRank(song.entry)};
+
+            SOCKET_SCORE_MESSAGE = {"amazing": 0,
+                    "perfect": 0,
+                    "good": 0,
+                    "average": 0,
+                    "miss": 0,
+                    "boo": 0,
+                    "score": 0,
+                    "combo": 0,
+                    "maxcombo": 0,
+                    "restarts": 0,
+                    "last_hit": null};
 
             // Init Game
             initUI();
@@ -641,18 +644,19 @@ package game
                 // Websocket
                 if (_gvars.air_useWebsockets)
                 {
-                    SOCKET_MESSAGE["score"]["amazing"] = hitAmazing;
-                    SOCKET_MESSAGE["score"]["perfect"] = hitPerfect;
-                    SOCKET_MESSAGE["score"]["good"] = hitGood;
-                    SOCKET_MESSAGE["score"]["average"] = hitAverage;
-                    SOCKET_MESSAGE["score"]["boo"] = hitBoo;
-                    SOCKET_MESSAGE["score"]["miss"] = hitMiss;
-                    SOCKET_MESSAGE["score"]["combo"] = hitCombo;
-                    SOCKET_MESSAGE["score"]["maxcombo"] = hitMaxCombo;
-                    SOCKET_MESSAGE["score"]["score"] = gameScore;
-                    SOCKET_MESSAGE["score"]["last_hit"] = null;
-                    SOCKET_MESSAGE["score"]["restarts"] = _gvars.songRestarts;
-                    _gvars.websocketSend("SONG_START", SOCKET_MESSAGE);
+                    SOCKET_SCORE_MESSAGE["amazing"] = hitAmazing;
+                    SOCKET_SCORE_MESSAGE["perfect"] = hitPerfect;
+                    SOCKET_SCORE_MESSAGE["good"] = hitGood;
+                    SOCKET_SCORE_MESSAGE["average"] = hitAverage;
+                    SOCKET_SCORE_MESSAGE["boo"] = hitBoo;
+                    SOCKET_SCORE_MESSAGE["miss"] = hitMiss;
+                    SOCKET_SCORE_MESSAGE["combo"] = hitCombo;
+                    SOCKET_SCORE_MESSAGE["maxcombo"] = hitMaxCombo;
+                    SOCKET_SCORE_MESSAGE["score"] = gameScore;
+                    SOCKET_SCORE_MESSAGE["last_hit"] = null;
+                    SOCKET_SCORE_MESSAGE["restarts"] = _gvars.songRestarts;
+                    _gvars.websocketSend("NOTE_JUDGE", SOCKET_SCORE_MESSAGE);
+                    _gvars.websocketSend("SONG_START", SOCKET_SONG_MESSAGE);
                 }
             }
         }
@@ -1166,7 +1170,7 @@ package game
 
                 if (_gvars.air_useWebsockets)
                 {
-                    _gvars.websocketSend("SONG_PAUSE", SOCKET_MESSAGE);
+                    _gvars.websocketSend("SONG_PAUSE", SOCKET_SONG_MESSAGE);
                 }
             }
             else if (GAME_STATE == GAME_PAUSE)
@@ -1177,7 +1181,7 @@ package game
 
                 if (_gvars.air_useWebsockets)
                 {
-                    _gvars.websocketSend("SONG_RESUME", SOCKET_MESSAGE);
+                    _gvars.websocketSend("SONG_RESUME", SOCKET_SONG_MESSAGE);
                 }
             }
         }
@@ -1260,17 +1264,18 @@ package game
             // Websocket
             if (_gvars.air_useWebsockets)
             {
-                SOCKET_MESSAGE["score"]["amazing"] = hitAmazing;
-                SOCKET_MESSAGE["score"]["perfect"] = hitPerfect;
-                SOCKET_MESSAGE["score"]["good"] = hitGood;
-                SOCKET_MESSAGE["score"]["average"] = hitAverage;
-                SOCKET_MESSAGE["score"]["boo"] = hitBoo;
-                SOCKET_MESSAGE["score"]["miss"] = hitMiss;
-                SOCKET_MESSAGE["score"]["combo"] = hitCombo;
-                SOCKET_MESSAGE["score"]["maxcombo"] = hitMaxCombo;
-                SOCKET_MESSAGE["score"]["score"] = gameScore;
-                SOCKET_MESSAGE["score"]["last_hit"] = null;
-                _gvars.websocketSend("SONG_END", SOCKET_MESSAGE);
+                SOCKET_SCORE_MESSAGE["amazing"] = hitAmazing;
+                SOCKET_SCORE_MESSAGE["perfect"] = hitPerfect;
+                SOCKET_SCORE_MESSAGE["good"] = hitGood;
+                SOCKET_SCORE_MESSAGE["average"] = hitAverage;
+                SOCKET_SCORE_MESSAGE["boo"] = hitBoo;
+                SOCKET_SCORE_MESSAGE["miss"] = hitMiss;
+                SOCKET_SCORE_MESSAGE["combo"] = hitCombo;
+                SOCKET_SCORE_MESSAGE["maxcombo"] = hitMaxCombo;
+                SOCKET_SCORE_MESSAGE["score"] = gameScore;
+                SOCKET_SCORE_MESSAGE["last_hit"] = null;
+                _gvars.websocketSend("NOTE_JUDGE", SOCKET_SCORE_MESSAGE);
+                _gvars.websocketSend("SONG_END", SOCKET_SONG_MESSAGE);
             }
 
             // Cleanup
@@ -1391,8 +1396,9 @@ package game
             // Websocket
             if (_gvars.air_useWebsockets)
             {
-                SOCKET_MESSAGE["score"]["restarts"] = _gvars.songRestarts;
-                _gvars.websocketSend("SONG_RESTART", SOCKET_MESSAGE);
+                SOCKET_SCORE_MESSAGE["restarts"] = _gvars.songRestarts;
+                _gvars.websocketSend("NOTE_JUDGE", SOCKET_SCORE_MESSAGE);
+                _gvars.websocketSend("SONG_RESTART", SOCKET_SONG_MESSAGE);
             }
         }
 
@@ -2020,17 +2026,17 @@ package game
             // Websocket
             if (_gvars.air_useWebsockets)
             {
-                SOCKET_MESSAGE["score"]["amazing"] = hitAmazing;
-                SOCKET_MESSAGE["score"]["perfect"] = hitPerfect;
-                SOCKET_MESSAGE["score"]["good"] = hitGood;
-                SOCKET_MESSAGE["score"]["average"] = hitAverage;
-                SOCKET_MESSAGE["score"]["boo"] = hitBoo;
-                SOCKET_MESSAGE["score"]["miss"] = hitMiss;
-                SOCKET_MESSAGE["score"]["combo"] = hitCombo;
-                SOCKET_MESSAGE["score"]["maxcombo"] = hitMaxCombo;
-                SOCKET_MESSAGE["score"]["score"] = gameScore;
-                SOCKET_MESSAGE["score"]["last_hit"] = score;
-                _gvars.websocketSend("NOTE_JUDGE", SOCKET_MESSAGE);
+                SOCKET_SCORE_MESSAGE["amazing"] = hitAmazing;
+                SOCKET_SCORE_MESSAGE["perfect"] = hitPerfect;
+                SOCKET_SCORE_MESSAGE["good"] = hitGood;
+                SOCKET_SCORE_MESSAGE["average"] = hitAverage;
+                SOCKET_SCORE_MESSAGE["boo"] = hitBoo;
+                SOCKET_SCORE_MESSAGE["miss"] = hitMiss;
+                SOCKET_SCORE_MESSAGE["combo"] = hitCombo;
+                SOCKET_SCORE_MESSAGE["maxcombo"] = hitMaxCombo;
+                SOCKET_SCORE_MESSAGE["score"] = gameScore;
+                SOCKET_SCORE_MESSAGE["last_hit"] = score;
+                _gvars.websocketSend("NOTE_JUDGE", SOCKET_SCORE_MESSAGE);
             }
         }
 


### PR DESCRIPTION
- Fix Isolation and Rates information on WebSockets.
- Fix Song Length, Note Count, and Avg NPS being incorrect for Alt Engines if info is missing from the playlist.
- Split message into song info and score info to cut down on packet size during gameplay.
- Change Websocket message to use a static fixed message object instead of creating new messages each time.

Web Overlay is also updated to support these changes.