### PR TITLE
Fix a crash caused by passing null to showButton

### DIFF
--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -389,6 +389,9 @@ package arc.mp
 
         private function showButton(button:BoxButton, show:Boolean):void
         {
+            if (button == null)
+                return;
+            
             if (button.parent == null && show)
                 addChild(button);
             else if (button.parent == this && !show)


### PR DESCRIPTION
This has only happened in debug sessions so far.

Occasionally, upon reaching the results screen, this error pops up. It happens both when you play as a guest or when you're logged in. The error appears to be random though.