### PR TITLE
Save Websockets setting properly

### DIFF
--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -1801,6 +1801,7 @@ package popups
                 {
                     _gvars.destroyWebsocketServer();
                     _gvars.air_useWebsockets = false;
+                    LocalStore.setVariable("air_useWebsockets", _gvars.air_useWebsockets);
                 }
                 else
                 {


### PR DESCRIPTION
When the Websockets setting is turned on, you can turn it off in-game, but restarting the game turns the setting on again. This is due to missing logic that saves the Websockets setting to LocalStore whenever its checkbox is toggled.