### PR TITLE
Simplify setActiveIndex in MenuSongSelection

### DIFF
--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -644,7 +644,7 @@ package menu
                 song = songList[sX];
                 if (options.activeSongID == song.level)
                 {
-                    setActiveIndex(sX, -1, false);
+                    setActiveIndex(sX, -1);
                     hasSelected = true;
                     break;
                 }
@@ -740,28 +740,25 @@ package menu
         }
 
         /**
-         * Sets the active song id from the song items list based on the given index.
-         * @param item_index Index in the Song Items array.
-         * @param mpUpdate Send update to multiplayer for selection.
-         */
-        private function setActiveSongID(item_index:int, mpUpdate:Boolean):void
-        {
-            options.activeSongID = (songItems.length > 0 && item_index < songItems.length ? songItems[item_index].level : -1);
-            if (mpUpdate && options.activeSongID != -1)
-                _mp.gameplayPicking(_playlist.getSong(options.activeSongID));
-        }
-
-        /**
          * Selects and highlights a Song Item in the playlist for the given index.
          * @param index New Index
          * @param last Last Selected Index, if not -1, unhighlights the given index.
          * @param doScroll Scrolls to the song item when true.
+         * @param mpUpdate Send update to multiplayer for selection. Only send for user selection events.
          */
-        public function setActiveIndex(index:int, last:int, doScroll:Boolean = false):void
+        public function setActiveIndex(index:int, last:int, doScroll:Boolean = false, mpUpdate:Boolean = false):void
         {
             // No need to do anything if nothing changed, or nothing to select
-            if (index == last || songItems.length <= 0)
+            if (index == last)
                 return;
+
+            // Reset on invalid index.
+            if (songItems.length <= 0 || index < 0 || index >= songItems.length)
+            {
+                options.activeIndex = -1;
+                options.activeSongID = -1;
+                return;
+            }
 
             // Set Index
             options.activeIndex = index;
@@ -774,7 +771,7 @@ package menu
             }
 
             // Set Song
-            setActiveSongID(index, true);
+            options.activeSongID = songItems[index].level;
 
             // Set Active Highlights
             songItems[index].active = true;
@@ -789,6 +786,10 @@ package menu
                 pane.scrollTo(scrollVal);
                 scrollbar.scrollTo(scrollVal);
             }
+
+            // Update Multiplayer Selection
+            if (mpUpdate && options.activeSongID != -1)
+                _mp.gameplayPicking(_playlist.getSong(options.activeSongID));
         }
 
         /**
@@ -806,7 +807,7 @@ package menu
                 if (tarSongItem.index != options.activeIndex)
                 {
                     options.infoTab = TAB_PLAYLIST;
-                    setActiveIndex(tarSongItem.index, options.activeIndex);
+                    setActiveIndex(tarSongItem.index, options.activeIndex, false, true);
                     buildInfoBox();
                 }
                 else
@@ -1445,7 +1446,7 @@ package menu
             for (var i:int = 0; i < songItems.length; i++)
             {
                 if (songItems[i].level == options.activeSongID)
-                    setActiveIndex(i, -1, true);
+                    setActiveIndex(i, -1, true, true);
             }
         }
 
@@ -1875,7 +1876,7 @@ package menu
                 {
                     if (!songItems[newIndex].isLocked)
                     {
-                        setActiveIndex(newIndex, lastIndex, true);
+                        setActiveIndex(newIndex, lastIndex, true, true);
                         buildInfoBox();
                         stage.focus = null;
                         break;

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -644,7 +644,7 @@ package menu
                 song = songList[sX];
                 if (options.activeSongID == song.level)
                 {
-                    setActiveIndex(sX, -1);
+                    setActiveIndex(sX, -1, false, false);
                     hasSelected = true;
                     break;
                 }
@@ -660,7 +660,7 @@ package menu
             // No song selected, select the first in the list if valid.
             if (options.activeIndex == -1)
             {
-                setActiveIndex(0, -1);
+                setActiveIndex(0, -1, false, false);
             }
         }
 
@@ -746,7 +746,7 @@ package menu
          * @param doScroll Scrolls to the song item when true.
          * @param mpUpdate Send update to multiplayer for selection. Only send for user selection events.
          */
-        public function setActiveIndex(index:int, last:int, doScroll:Boolean = false, mpUpdate:Boolean = false):void
+        public function setActiveIndex(index:int, last:int, doScroll:Boolean = false, mpUpdate:Boolean = true):void
         {
             // No need to do anything if nothing changed, or nothing to select
             if (index == last)
@@ -807,7 +807,7 @@ package menu
                 if (tarSongItem.index != options.activeIndex)
                 {
                     options.infoTab = TAB_PLAYLIST;
-                    setActiveIndex(tarSongItem.index, options.activeIndex, false, true);
+                    setActiveIndex(tarSongItem.index, options.activeIndex);
                     buildInfoBox();
                 }
                 else
@@ -1446,7 +1446,7 @@ package menu
             for (var i:int = 0; i < songItems.length; i++)
             {
                 if (songItems[i].level == options.activeSongID)
-                    setActiveIndex(i, -1, true, true);
+                    setActiveIndex(i, -1, true);
             }
         }
 
@@ -1876,7 +1876,7 @@ package menu
                 {
                     if (!songItems[newIndex].isLocked)
                     {
-                        setActiveIndex(newIndex, lastIndex, true, true);
+                        setActiveIndex(newIndex, lastIndex, true);
                         buildInfoBox();
                         stage.focus = null;
                         break;


### PR DESCRIPTION
- Remove setActiveSongID() as it used to be used in restoring temp flags but now is only called within setActiveIndex(), making it redundent.
- Add mpUpdate parameter to control sending song selection updates to MP when the playlist auto-selects a song instead of the user.
- Reset activeIndex and activeSongID on invalid index selection.
