### PR TITLE
More song selection menu improvements

### DIFF
--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -807,7 +807,7 @@ package menu
                 }
                 else
                 {
-                    if (tarSongItem.isLocked == false && options.infoTab == TAB_PLAYLIST)
+                    if (!tarSongItem.isLocked && options.infoTab == TAB_PLAYLIST)
                     {
                         if (_mp.gameplayHasOpponent())
                             multiplayerLoad(tarSongItem.level);

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -798,7 +798,7 @@ package menu
             if (e.target is SongItem)
             {
                 var tarSongItem:SongItem = (e.target as SongItem);
-                var isLocked:Boolean = tarSongItem.e_onClick(e);
+                tarSongItem.e_onClick(e);
                 if (tarSongItem.index != options.activeIndex)
                 {
                     options.infoTab = TAB_PLAYLIST;
@@ -807,7 +807,7 @@ package menu
                 }
                 else
                 {
-                    if (isLocked == false && options.infoTab == TAB_PLAYLIST)
+                    if (tarSongItem.isLocked == false && options.infoTab == TAB_PLAYLIST)
                     {
                         if (_mp.gameplayHasOpponent())
                             multiplayerLoad(tarSongItem.level);

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -768,7 +768,10 @@ package menu
             // Set Active Highlights
             songItems[index].active = true;
             if (last >= 0 && last < songItems.length)
+            {
+                songItems[last].highlight = false;
                 songItems[last].active = false;
+            }
 
             // Scroll when doScroll is set.
             if (doScroll && scrollbar.draggerVisibility)

--- a/src/menu/MenuSongSelectionOptions.as
+++ b/src/menu/MenuSongSelectionOptions.as
@@ -16,5 +16,7 @@ package menu
 
         public var isFilter:Boolean = false;
         public var filter:Function = null;
+
+        public var queuePlaylist:Array = [];
     }
 }

--- a/src/menu/MenuTokens.as
+++ b/src/menu/MenuTokens.as
@@ -196,20 +196,22 @@ package menu
 
         private function e_tokenClick(e:Event):void
         {
-            _gvars.songQueue = [];
-
+            var token_songs:Array = [];
             for each (var level:int in(e.target as TokenItem).token_levels)
             {
                 if (level > 0)
                 {
                     var songData:Object = _playlist.getSong(level);
                     if (songData.error == null)
-                        _gvars.songQueue.push(songData);
+                        token_songs.push(songData);
                 }
             }
 
-            if (_gvars.songQueue.length <= 0)
+            if (token_songs.length <= 0)
                 return;
+
+            _gvars.songQueue = token_songs;
+            MenuSongSelection.options.queuePlaylist = _gvars.songQueue;
 
             switchTo(MainMenu.MENU_SONGSELECTION);
             MenuSongSelection.options.infoTab = MenuSongSelection.TAB_QUEUE;

--- a/src/menu/SongItem.as
+++ b/src/menu/SongItem.as
@@ -3,8 +3,6 @@ package menu
     import classes.Text;
     import flash.display.Sprite;
     import flash.display.GradientType;
-    import flash.geom.Matrix;
-    import flash.text.StyleSheet;
     import flash.events.MouseEvent;
     import com.flashfla.utils.sprintf;
     import com.flashfla.utils.NumberUtil;
@@ -108,9 +106,8 @@ package menu
                 {
                     navigateToURL(new URLRequest(Constant.SHOP_URL), "_blank");
                 }
-                return true;
             }
-            return false;
+            return isLocked;
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -232,6 +229,12 @@ package menu
         public function get level():int
         {
             return _level;
+        }
+
+        public function set highlight(val:Boolean):void
+        {
+            _highlight = val;
+            draw();
         }
 
         public function get highlight():Boolean


### PR DESCRIPTION
New features:
- The queue playlist is now saved after gameplays.
- A button has been added that allows players to play their queue starting from a selected song.

Fixes:
- Don't attempt loading locked songs when they're clicked.
- Don't reset the page number, scroll position and active song info when clicking the queue tab button while the queue playlist is being displayed.
- Display song info whenever the genre is changed or a `PageBox` is clicked.
- Ensure that the previously selected song is no longer highlighted. If you put your mouse over a song item, don't move it and navigate the song selection menu with the up/down keys, the previous song would be highlighted when it should no longer be.
- Simplify the logic for handling song navigation key presses. Previously, this logic is changed because highlighting locked songs in the playlist caused rendering errors. These errors no longer occur, so this logic is reverted back to its original version.