### PR TITLE
Enable playing song previews in song selection menu

### DIFF
--- a/src/classes/SongPlayerBytes.as
+++ b/src/classes/SongPlayerBytes.as
@@ -10,15 +10,15 @@ package classes
     {
         public var sound:Sound;
         public var soundChannel:SoundChannel;
-        public var _playFlag:Boolean = false;
 
         public var isPlaying:Boolean = false;
         public var userPaused:Boolean = false;
         public var userStopped:Boolean = false;
 
         private var pausePosition:int = 0;
+        private var _noRepeat:Boolean;
 
-        public function SongPlayerBytes(swfBytes:ByteArray, isMP3File:Boolean = false)
+        public function SongPlayerBytes(swfBytes:ByteArray, isMP3File:Boolean = false, noRepeat:Boolean = false)
         {
             if (swfBytes && swfBytes.length > 0)
             {
@@ -29,19 +29,14 @@ package classes
                 sound = new Sound();
                 sound.loadCompressedDataFromByteArray(swfBytes, swfBytes.length);
             }
+            _noRepeat = noRepeat;
         }
 
         public function start():void
         {
-            if (!sound)
-            {
-                _playFlag = true;
-                return;
-            }
-            if (userPaused)
+            if (!sound || userPaused)
                 return;
 
-            _playFlag = false;
             stop();
             soundChannel = sound.play(pausePosition);
             soundChannel.soundTransform = GlobalVariables.instance.menuMusicSoundTransform;
@@ -53,7 +48,10 @@ package classes
         {
             SoundChannel(e.target).removeEventListener(e.type, onComplete);
             pausePosition = 0;
-            start();
+            if (_noRepeat)
+                isPlaying = false;
+            else
+                start();
         }
 
         public function stop():void

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -48,6 +48,7 @@ package game
     import game.controls.Score;
     import it.gotoandplay.smartfoxserver.SFSEvent;
     import menu.MenuPanel;
+    import menu.MenuSongSelection;
     import sql.SQLSongDetails;
 
     public class GamePlay extends MenuPanel
@@ -228,6 +229,9 @@ package game
         {
             if (_gvars.menuMusic)
                 _gvars.menuMusic.stop();
+
+            if (MenuSongSelection.previewMusic)
+                MenuSongSelection.previewMusic.stop();
 
             // var stage3D:Stage3D = stage.stage3Ds[0];
             // stage.stage3Ds[0].addEventListener(Event.CONTEXT3D_CREATE, initStage3D);

--- a/src/menu/MainMenu.as
+++ b/src/menu/MainMenu.as
@@ -28,7 +28,6 @@ package menu
     import flash.ui.ContextMenuItem;
     import popups.PopupFilterManager;
     import popups.PopupSkillRankUpdate;
-    import game.GamePlay;
 
     public class MainMenu extends MenuPanel
     {
@@ -249,7 +248,8 @@ package menu
                 spr_play.borderAlpha = 0.75;
                 spr_play.x = 5;
                 spr_play.y = 5;
-                with (spr_play.graphics)
+                var playIcon:Sprite = new Sprite();
+                with (playIcon.graphics)
                 {
                     lineStyle(1, 0xFFFFFF, 0);
                     beginFill(0xFFFFFF, 0.75);
@@ -259,6 +259,7 @@ package menu
                     lineTo(7, 6);
                     endFill();
                 }
+                spr_play.addChild(playIcon);
                 spr_play.addEventListener(MouseEvent.CLICK, function(e:Event):void
                 {
                     if (_gvars.menuMusic && !_gvars.menuMusic.isPlaying)
@@ -272,7 +273,8 @@ package menu
                 spr_pause.borderAlpha = 0.75;
                 spr_pause.x = 35;
                 spr_pause.y = 5;
-                with (spr_pause.graphics)
+                var pauseIcon:Sprite = new Sprite();
+                with (pauseIcon.graphics)
                 {
                     lineStyle(1, 0xFFFFFF, 0);
                     beginFill(0xFFFFFF, 0.75);
@@ -280,6 +282,7 @@ package menu
                     drawRect(14, 6, 5, 15);
                     endFill();
                 }
+                spr_pause.addChild(pauseIcon);
                 spr_pause.addEventListener(MouseEvent.CLICK, function(e:Event):void
                 {
                     if (_gvars.menuMusic && _gvars.menuMusic.isPlaying)
@@ -293,13 +296,15 @@ package menu
                 spr_stop.borderAlpha = 0.75;
                 spr_stop.x = 65;
                 spr_stop.y = 5;
-                with (spr_stop.graphics)
+                var stopIcon:Sprite = new Sprite();
+                with (stopIcon.graphics)
                 {
                     lineStyle(1, 0xFFFFFF, 0);
                     beginFill(0xFFFFFF, 0.75);
                     drawRect(6, 6, 13, 15);
                     endFill();
                 }
+                spr_stop.addChild(stopIcon);
                 spr_stop.addEventListener(MouseEvent.CLICK, function(e:Event):void
                 {
                     if (_gvars.menuMusic && _gvars.menuMusic.isPlaying)
@@ -313,7 +318,8 @@ package menu
                 spr_delete.borderAlpha = 0.75;
                 spr_delete.x = 95;
                 spr_delete.y = 5;
-                with (spr_delete.graphics)
+                var deleteIcon:Sprite = new Sprite();
+                with (deleteIcon.graphics)
                 {
                     lineStyle(1, 0xFFFFFF, 0);
                     beginFill(0xFFFFFF, 0.75);
@@ -330,6 +336,7 @@ package menu
                     lineTo(11, 5);
                     endFill();
                 }
+                spr_delete.addChild(deleteIcon);
                 menuMusicControls.addChild(spr_delete);
                 spr_delete.addEventListener(MouseEvent.CLICK, function(e:Event):void
                 {

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -101,6 +101,8 @@ package menu
         private var songItemContextMenuItem:ContextMenuItem;
         private var songItemRemoveQueueContext:ContextMenuItem;
 
+        public static var previewMusic:SongPlayerBytes;
+
         ///- Constructor
         public function MenuSongSelection(myParent:MenuPanel)
         {
@@ -142,6 +144,10 @@ package menu
             songItemContextMenu = new ContextMenu();
             songItemContextMenuItem = new ContextMenuItem("Set as Menu Music");
             songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_setAsMenuMusicContextSelect);
+            songItemContextMenu.customItems.push(songItemContextMenuItem);
+
+            songItemContextMenuItem = new ContextMenuItem("Listen to Song Preview");
+            songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_listenToSongPreviewContextSelect);
             songItemContextMenu.customItems.push(songItemContextMenuItem);
 
             if (_gvars.sql_connect)
@@ -839,7 +845,7 @@ package menu
         }
 
         /**
-         * Song Item Context Menu: Sets the interacted as the current menu music.
+         * Song Item Context Menu: Sets the interacted song as the current menu music.
          * This handles loading the music in the background if not already loaded,
          * or sets the music from the already loaded copy if available.
          * @param e
@@ -865,6 +871,35 @@ package menu
                 {
                     _gvars.gameMain.addAlert("Loading Music for \"" + songData["name"] + "\"", 90);
                     song.addEventListener(Event.COMPLETE, e_menuMusicConvertSongLoad);
+                }
+            }
+        }
+
+        /**
+         * Song Item Context Menu: Same as for setting a song as the current menu music,
+         * but for playing a song preview instead.
+         * @param e
+         */
+        private function e_listenToSongPreviewContextSelect(e:ContextMenuEvent):void
+        {
+            if (!_gvars.options)
+            {
+                _gvars.options = new GameOptions();
+                _gvars.options.fill();
+            }
+            var songItem:SongItem = (e.contextMenuOwner as SongItem);
+            var songData:Object = _playlist.getSong(songItem.level);
+            if (songData.error == null)
+            {
+                var song:Song = _gvars.getSongFile(songData);
+                if (song.isLoaded)
+                {
+                    playSongPreview(song);
+                }
+                else
+                {
+                    _gvars.gameMain.addAlert("Loading Music for \"" + songData["name"] + "\"", 90);
+                    song.addEventListener(Event.COMPLETE, e_songPreviewConvertSongLoad);
                 }
             }
         }
@@ -1905,6 +1940,16 @@ package menu
         }
 
         /**
+         * Callback for menu song preview when loaded and available.
+         */
+        private function e_songPreviewConvertSongLoad(e:Event):void
+        {
+            var song:Song = (e.target as Song);
+            song.removeEventListener(Event.COMPLETE, e_songPreviewConvertSongLoad);
+            playSongPreview(song);
+        }
+
+        /**
          * Begins play of a loaded Song class object.
          * This updates the stored song name, begins music playback
          * and display the song controls.
@@ -1912,6 +1957,8 @@ package menu
          */
         private function playMenuMusicSong(song:Song):void
         {
+            _gvars.gameMain.addAlert("Playing menu music...");
+
             LocalStore.setVariable("menu_music", song.entry.name);
             var par:MainMenu = ((this.my_Parent) as MainMenu);
             if (par.menuMusicControls)
@@ -1920,9 +1967,30 @@ package menu
             if (_gvars.menuMusic)
                 _gvars.menuMusic.stop();
 
+            if (previewMusic)
+                previewMusic.stop();
+
             _gvars.menuMusic = new SongPlayerBytes(song.bytesSWF);
             _gvars.menuMusic.start();
             par.drawMenuMusicControls();
+        }
+        
+        /**
+         * Same as playMenuMusicSong, but it plays the song preview without repeat
+         * and the song controls aren't drawn.
+         */
+        private function playSongPreview(song:Song):void
+        {
+            _gvars.gameMain.addAlert("Playing song preview...");
+
+            if (_gvars.menuMusic)
+                _gvars.menuMusic.stop();
+
+            if (previewMusic)
+                previewMusic.stop();
+
+            previewMusic = new SongPlayerBytes(song.bytesSWF, false, true);
+            previewMusic.start();
         }
 
         /**


### PR DESCRIPTION
Closes #21.

New features:
- A new button has been added into the context menus of song items that allows playing them once for preview.
- `SongPlayerBytes` now has a new constructor parameter that allows setting whether a song could be played on repeat.
- When gameplay starts, the song preview music is stopped if it's found to be playing.

Fixes:
- When hovering the mouse over the menu music buttons, their icons disappear due to the way `Box`s are rendered. These icons are now `Sprite`s and are added as children into the buttons instead.
- Removed unused `_playFlag` property in `SongPlayerBytes`.