### PR TITLE
Add friends menu

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -12,6 +12,7 @@ package
     import assets.GameBackgroundColor;
     import classes.Alert;
     import classes.BoxButton;
+    import classes.Friends;
     import classes.Language;
     import classes.Noteskins;
     import classes.Playlist;
@@ -68,7 +69,7 @@ package
         public var _site:Site = Site.instance;
         public var _playlist:Playlist = Playlist.instance;
         public var _lang:Language = Language.instance;
-        //public var _friends:Friends = Friends.instance;
+        public var _friends:Friends = Friends.instance;
         public var _noteskins:Noteskins = Noteskins.instance;
 
         public var loadTimer:int = 0;
@@ -266,7 +267,7 @@ package
             //- Status Display
             loadStatus = new TextField();
             loadStatus.x = 8;
-            loadStatus.y = GAME_HEIGHT - ((isLoginLoad) ? 118 : 155);
+            loadStatus.y = GAME_HEIGHT - ((isLoginLoad) ? 134 : 171);
             loadStatus.width = GAME_WIDTH - 20;
             loadStatus.selectable = false;
             loadStatus.embedFonts = true;
@@ -288,7 +289,7 @@ package
         ///- Game Data
         public function loadGameData():void
         {
-            loadTotal = (!isLoginLoad) ? 5 : 3;
+            loadTotal = (!isLoginLoad) ? 6 : 4;
 
             _gvars.playerUser = new User(true, true);
             _gvars.activeUser = _gvars.playerUser;
@@ -299,8 +300,11 @@ package
             _site.addEventListener(GlobalVariables.LOAD_ERROR, gameScriptLoadError);
             _playlist.addEventListener(GlobalVariables.LOAD_COMPLETE, gameScriptLoad);
             _playlist.addEventListener(GlobalVariables.LOAD_ERROR, gameScriptLoadError);
+            _friends.addEventListener(GlobalVariables.LOAD_COMPLETE, gameScriptLoad);
+            _friends.addEventListener(GlobalVariables.LOAD_ERROR, gameScriptLoadError);
             _site.load();
             _playlist.load();
+            _friends.load();
 
             if (!isLoginLoad)
             {
@@ -311,10 +315,6 @@ package
                 _lang.load();
                 _noteskins.load();
             }
-
-            //_friends.addEventListener(GlobalVariables.LOAD_COMPLETE, gameScriptLoad);
-            //_friends.addEventListener(GlobalVariables.LOAD_ERROR, gameScriptLoadError);
-            //_friends.load();
 
             // Update Text
             updateLoaderText();
@@ -345,7 +345,7 @@ package
         {
             if (loadStatus != null)
             {
-                loadStatus.htmlText = "Total: " + loadScripts + " / " + loadTotal + "\n" + "Playlist: " + getLoadText(_playlist.isLoaded(), _playlist.isError()) + "\n" + "User Data: " + getLoadText(_gvars.playerUser.isLoaded(), _gvars.playerUser.isError()) + "\n" + "Site Data: " + getLoadText(_site.isLoaded(), _site.isError()) + ((!isLoginLoad) ? ("\n" + "Noteskin Data: " + getLoadText(_noteskins.isLoaded(), _noteskins.isError()) + "\n" + "Language Data: " + getLoadText(_lang.isLoaded(), _lang.isError())) : "");
+                loadStatus.htmlText = "Total: " + loadScripts + " / " + loadTotal + "\n" + "Playlist: " + getLoadText(_playlist.isLoaded(), _playlist.isError()) + "\n" + "User Data: " + getLoadText(_gvars.playerUser.isLoaded(), _gvars.playerUser.isError()) + "\n" + "Site Data: " + getLoadText(_site.isLoaded(), _site.isError()) + "\n" + "Friends Data: " + getLoadText(_friends.isLoaded(), _friends.isError()) + ((!isLoginLoad) ? ("\n" + "Noteskin Data: " + getLoadText(_noteskins.isLoaded(), _noteskins.isError()) + "\n" + "Language Data: " + getLoadText(_lang.isLoaded(), _lang.isError())) : "");
             }
         }
 
@@ -471,13 +471,12 @@ package
                 _gvars.activeUser.addEventListener(GlobalVariables.LOAD_ERROR, gameScriptLoadError);
                 _gvars.activeUser.load();
             }
-            /*
-               if (!_friends.isLoaded()) {
-               _friends.addEventListener(GlobalVariables.LOAD_COMPLETE, gameScriptLoad);
-               _friends.addEventListener(GlobalVariables.LOAD_ERROR, gameScriptLoadError);
-               _friends.load();
-               }
-             */
+            if (!_friends.isLoaded())
+            {
+                _friends.addEventListener(GlobalVariables.LOAD_COMPLETE, gameScriptLoad);
+                _friends.addEventListener(GlobalVariables.LOAD_ERROR, gameScriptLoadError);
+                _friends.load();
+            }
             if (!isLoginLoad)
             {
                 if (!_noteskins.isLoaded())

--- a/src/arc/mp/MultiplayerSingleton.as
+++ b/src/arc/mp/MultiplayerSingleton.as
@@ -3,14 +3,11 @@ package arc.mp
     import menu.MenuPanel;
     import menu.MainMenu;
     import menu.MenuSongSelection;
-    import game.GamePlay;
-    import game.GameMenu;
     import game.GameOptions;
     import classes.Playlist;
     import classes.chart.Song;
     import classes.replay.Replay;
     import GlobalVariables;
-    import arc.ArcGlobals;
     import arc.mp.MultiplayerPanel;
     import flash.net.URLVariables;
     import flash.net.URLLoader;
@@ -22,8 +19,6 @@ package arc.mp
     import flash.events.Event;
     import com.flashfla.net.Multiplayer;
     import it.gotoandplay.smartfoxserver.SFSEvent;
-
-    import com.bit101.components.TextArea;
 
     public class MultiplayerSingleton extends Object
     {
@@ -52,7 +47,7 @@ package arc.mp
 
         public static function destroyInstance():void
         {
-            if (instance.connection.connected)
+            if (instance && instance.connection && instance.connection.connected)
                 instance.connection.disconnect();
             instance = null;
         }

--- a/src/menu/FriendItem.as
+++ b/src/menu/FriendItem.as
@@ -14,14 +14,11 @@ package menu
         //- Song Details
         private var nameText:Text;
         private var statusText:Text;
-        public var index:Number;
-        public var box:Box;
 
-        public function FriendItem(user_data:Object, isActive:Boolean = false):void
+        public function FriendItem(user_data:Object):void
         {
             this.user_data = user_data;
-            this.active = isActive;
-            super(577, 27 + (isActive ? 60 : 0), false);
+            super(577, 27, false);
         }
 
         override protected function init():void

--- a/src/menu/MainMenu.as
+++ b/src/menu/MainMenu.as
@@ -58,7 +58,7 @@ package menu
         private var statUpdaterBtn:SimpleBoxButton;
         private var rankUpdateThrobber:Throbber;
 
-        public var menuItems:Array = [["menu_play", MENU_SONGSELECTION], ["menu_multiplayer", MENU_MULTIPLAYER], ["menu_tokens", MENU_TOKENS], ["menu_filters", MENU_FILTERS], ["menu_options", MENU_OPTIONS]];
+        public var menuItems:Array;
         public var panel:MenuPanel;
         public var options:Object;
 
@@ -178,6 +178,32 @@ package menu
             panel.draw();
         }
 
+        public function rebuildMenu():void
+        {
+            // Tokens --> Tokens
+            if (options.activePanel == 3)
+            {
+                switchTo(MENU_TOKENS);
+            }
+            else if (options.activePanel == 2)
+            {
+                var enableFriendsMenu:Boolean = LocalStore.getVariable("enable_friends_menu", false);
+
+                // Tokens --> Friends
+                if (enableFriendsMenu)
+                {
+                    switchTo(MENU_FRIENDS);
+                }
+
+                // Friends --> Tokens
+                else
+                {
+                    switchTo(MENU_TOKENS);
+                }
+            }
+            this.draw();
+        }
+
         public function buildMenuItems():void
         {
             if (menuItemBox != null)
@@ -187,6 +213,17 @@ package menu
 
                 this.removeChild(user_text);
                 user_text = null;
+            }
+
+            //- Configure menu item array
+            var enableFriendsMenu:Boolean = LocalStore.getVariable("enable_friends_menu", false);
+            if (enableFriendsMenu)
+            {
+                menuItems = [["menu_play", MENU_SONGSELECTION], ["menu_multiplayer", MENU_MULTIPLAYER], ["menu_friends", MENU_FRIENDS], ["menu_tokens", MENU_TOKENS], ["menu_filters", MENU_FILTERS], ["menu_options", MENU_OPTIONS]];
+            }
+            else
+            {
+                menuItems = [["menu_play", MENU_SONGSELECTION], ["menu_multiplayer", MENU_MULTIPLAYER], ["menu_tokens", MENU_TOKENS], ["menu_filters", MENU_FILTERS], ["menu_options", MENU_OPTIONS]];
             }
 
             //- User Info Display
@@ -220,10 +257,14 @@ package menu
             menuItemBox.y = 8;
 
             //- Add Menu Buttons
+            var gap:Number = 7;
+            var width:Number = (610 / menuItems.length) - gap;
+            var height:Number = 28;
+            var fontSize:int = (enableFriendsMenu) ? 11 : 12;
             for (var item:String in menuItems)
             {
-                var menuItem:MenuButton = new MenuButton(_lang.string(menuItems[item][0]), item == options.activePanel);
-                menuItem.x = Number(item) * 122;
+                var menuItem:MenuButton = new MenuButton(_lang.string(menuItems[item][0]), item == options.activePanel, width, height, fontSize);
+                menuItem.x = Number(item) * (width + gap);
                 menuItem.panel = menuItems[item][1];
                 menuItem.mouseChildren = false;
                 menuItem.useHandCursor = true;
@@ -383,6 +424,7 @@ package menu
                 this.removeChild(panel);
             }
 
+            var enableFriendsMenu:Boolean = LocalStore.getVariable("enable_friends_menu", false);
             switch (_panel)
             {
                 case MENU_SONGSELECTION:
@@ -400,28 +442,28 @@ package menu
                     options.activePanel = 1;
                     isFound = true;
                     break;
-                /*
-                   case MENU_FRIENDS:
-                   if (_MenuFriends == null || useNew)
-                   _MenuFriends = new MenuFriends(this);
-                   panel = _MenuFriends;
-                   options.activePanel = 2;
-                   isFound = true;
-                   break;
-                   case MENU_STATS:
+
+                case MENU_FRIENDS:
+                    if (_MenuFriends == null || useNew)
+                        _MenuFriends = new MenuFriends(this);
+                    panel = _MenuFriends;
+                    options.activePanel = 2;
+                    isFound = true;
+                    break;
+
+                /* case MENU_STATS:
                    if (_MenuStats == null || useNew)
                    _MenuStats = new MenuStats(this);
                    panel = _MenuStats;
                    options.activePanel = 2;
                    isFound = true;
-                   break;
-                 */
+                   break; */
 
                 case MENU_TOKENS:
                     if (_MenuTokens == null || useNew)
                         _MenuTokens = new MenuTokens(this);
                     panel = _MenuTokens;
-                    options.activePanel = 2;
+                    options.activePanel = (enableFriendsMenu) ? 3 : 2;
                     isFound = true;
                     break;
             }

--- a/src/menu/MenuButton.as
+++ b/src/menu/MenuButton.as
@@ -11,9 +11,10 @@ package menu
         public var panel:String;
         public var index:String;
 
-        public function MenuButton(message:String, isActive:Boolean = false):void
+        public function MenuButton(message:String, isActive:Boolean = false, width:Number = 115, height:Number = 28, size:int = 12):void
         {
-            super(115, 28, message, 12, "#FFFFFF", true, true);
+            super(width, height, message, size, "#FFFFFF", true, true);
+            super.active = isActive;
         }
     }
 }

--- a/src/menu/MenuFriends.as
+++ b/src/menu/MenuFriends.as
@@ -26,7 +26,6 @@ package menu
         private var selectedGenre:Sprite;
         private var refreshButton:Text;
 
-        public var options:Object;
         public var isLoading:Boolean = false;
 
         public function MenuFriends(myParent:MenuPanel)
@@ -36,10 +35,6 @@ package menu
 
         override public function init():Boolean
         {
-            //- Setup Settings
-            options = new Object();
-            options.activeIndex = -1;
-
             //- Add Background
             background = new SongSelectionBackground();
             background.x = 145;
@@ -132,14 +127,10 @@ package menu
             var sI:FriendItem;
             for (var sX:int = 0; sX < friendsLength; sX++)
             {
-                sI = new FriendItem(_friends.list[sX], (options.activeIndex == sX));
+                sI = new FriendItem(_friends.list[sX]);
                 sI.y = yOffset + 30 * sX;
-                sI.index = sX;
-                sI.addEventListener(MouseEvent.CLICK, friendItemClick, false, 0, true);
                 pane.content.addChild(sI);
                 friendBoxItems[friendBoxItems.length] = sI;
-                if (options.activeIndex == sX)
-                    yOffset += 60;
             }
             pane.scrollTo(scrollbar.scroll, false);
             scrollbar.visible = (pane.content.height > pane.height);
@@ -160,22 +151,7 @@ package menu
         {
             _friends.removeEventListener(GlobalVariables.LOAD_COMPLETE, friendScriptLoad);
             _friends.removeEventListener(GlobalVariables.LOAD_ERROR, friendScriptLoad);
-            options.activeIndex = -1;
             isLoading = false;
-            buildFriends();
-        }
-
-        private function friendItemClick(e:Event = null):void
-        {
-            // Set Active
-            if (options.activeIndex != e.target.index)
-            {
-                options.activeIndex = e.target.index;
-            }
-            else if (options.activeIndex == e.target.index)
-            {
-                options.activeIndex = -1;
-            }
             buildFriends();
         }
 

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -144,6 +144,7 @@ package popups
         private var useWebsocketCheckbox:BoxCheck;
 
         private var flipGraphCheckbox:BoxCheck;
+        private var enableFriendsMenuCheckbox:BoxCheck;
 
         public function PopupOptions(myParent:MenuPanel)
         {
@@ -1149,6 +1150,19 @@ package popups
                 box.addChild(flipGraphCheckbox);
                 yOff += 30;
 
+                var enableFriendsMenuCheckboxText:Text = new Text("Enable Friends Menu");
+                enableFriendsMenuCheckboxText.x = xOff + 22;
+                enableFriendsMenuCheckboxText.y = yOff;
+                box.addChild(enableFriendsMenuCheckboxText);
+                yOff += 2;
+
+                enableFriendsMenuCheckbox = new BoxCheck();
+                enableFriendsMenuCheckbox.x = xOff + 2;
+                enableFriendsMenuCheckbox.y = yOff;
+                enableFriendsMenuCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
+                box.addChild(enableFriendsMenuCheckbox);
+                yOff += 30;
+
                 ///- Col 2
                 xOff += 176;
                 yOff = BASE_Y_POSITION;
@@ -1825,6 +1839,21 @@ package popups
                 LocalStore.setVariable("result_flip_graph", !flipGraph);
             }
 
+            // Enable Friends menu
+            else if (e.target == enableFriendsMenuCheckbox)
+            {
+                var enableFriendsMenu:Boolean = LocalStore.getVariable("enable_friends_menu", false);
+                LocalStore.setVariable("enable_friends_menu", !enableFriendsMenu);
+                if (_gvars.gameMain.activePanel is MainMenu)
+                {
+                    (_gvars.gameMain.activePanel as MainMenu).rebuildMenu();
+                }
+                else
+                {
+                    _gvars.gameMain.activePanel.draw();
+                }
+            }
+
             // Set Settings
             setSettings();
 
@@ -2109,6 +2138,9 @@ package popups
 
                 var flipGraph:Boolean = LocalStore.getVariable("result_flip_graph", false);
                 flipGraphCheckbox.checked = flipGraph;
+
+                var enableFriendsMenu:Boolean = LocalStore.getVariable("enable_friends_menu", false);
+                enableFriendsMenuCheckbox.checked = enableFriendsMenu;
             }
             // Save Local
             if (_gvars.activeUser == _gvars.playerUser)


### PR DESCRIPTION
Closes #15.

New features:
- The friends menu is now available in the main menu.
- Friends data is now loaded when the game starts up.
- It's disabled by default, but could be enabled via a toggle in the options menu.
- In the friends menu, don't do anything when a friends item is clicked.

Fixed bugs:
- Menu buttons are now highlighted when the corresponding menu is being displayed.
- When clicking on "Switch Profile" in the popup context menu, the multiplayer instance would be destroyed. If this button is then clicked again without logging into the game as a guest or player, a crash would occur. This crash shouldn't happen again.