### PR TITLE
Enable playing chart previews in song selection menu

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -413,7 +413,7 @@ package
                     }
                 }
 
-                if (_gvars.options && _gvars.options.replay)
+                if ((_gvars.flashvars.replay != null || _gvars.flashvars.preview_file != null) && _gvars.options && _gvars.options.replay)
                 {
                     if (_gvars.options.replay is SongPreview && !_gvars.options.replay.isLoaded)
                     {
@@ -424,8 +424,12 @@ package
                     {
                         loadScripts = 0;
                         preloader.remove();
-                        removeChild(loadStatus);
-                        removeChild(epilepsyWarning)
+
+                        if (this.contains(loadStatus))
+                            removeChild(loadStatus);
+                        if (this.contains(epilepsyWarning))
+                            removeChild(epilepsyWarning);
+
                         this.removeEventListener(Event.ENTER_FRAME, updatePreloader);
 
                         // Setup Vars

--- a/src/classes/replay/Replay.as
+++ b/src/classes/replay/Replay.as
@@ -1,6 +1,5 @@
 package classes.replay
 {
-
     import by.blooddy.crypto.MD5;
     import classes.User;
     import flash.events.Event;
@@ -71,6 +70,7 @@ package classes.replay
 
         private function replayLoadComplete(e:Event):void
         {
+            removeLoaderListeners();
             var site_data:Object = JSON.parse(e.target.data);
             if (site_data.result != 1)
             {
@@ -84,7 +84,7 @@ package classes.replay
 
         private function replayLoadError(e:Event):void
         {
-
+            removeLoaderListeners();
         }
 
         private function parseReplay(data:Object, loadUser:Boolean = true):void

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -894,6 +894,10 @@ package menu
 
             if (_gvars.options.replay.isLoaded)
             {
+                // Force no offsets on judge.
+                _gvars.options.offsetGlobal = 0;
+                _gvars.options.offsetJudge = 0;
+
                 // Setup Vars
                 _gvars.songQueue = [];
                 _gvars.songQueue.push(Playlist.instance.getSong(_gvars.options.replay.level));

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -18,6 +18,7 @@ package menu
     import classes.Language;
     import classes.Playlist;
     import classes.SongPlayerBytes;
+    import classes.SongPreview;
     import classes.SongQueueItem;
     import classes.StarSelector;
     import classes.Text;
@@ -142,6 +143,10 @@ package menu
             songItemContextMenu = new ContextMenu();
             songItemContextMenuItem = new ContextMenuItem("Set as Menu Music");
             songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_setAsMenuMusicContextSelect);
+            songItemContextMenu.customItems.push(songItemContextMenuItem);
+
+            songItemContextMenuItem = new ContextMenuItem("Play Chart Preview");
+            songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_playChartPreviewContextSelect);
             songItemContextMenu.customItems.push(songItemContextMenuItem);
 
             if (_gvars.sql_connect)
@@ -866,6 +871,37 @@ package menu
                     _gvars.gameMain.addAlert("Loading Music for \"" + songData["name"] + "\"", 90);
                     song.addEventListener(Event.COMPLETE, e_menuMusicConvertSongLoad);
                 }
+            }
+        }
+        
+        /**
+         * Song Item Context Menu: Plays the chart preview of the selected song.
+         */
+        private function e_playChartPreviewContextSelect(e:ContextMenuEvent):void
+        {
+            if (!_gvars.options)
+            {
+                _gvars.options = new GameOptions();
+                _gvars.options.fill();
+            }
+            _gvars.options.replay = new SongPreview((e.contextMenuOwner as SongItem).level);
+            _gvars.options.loadPreview = true;
+            _gvars.replayHistory.push(_gvars.options.replay);
+
+            if (!_gvars.options.replay.isLoaded)
+            {
+                (_gvars.options.replay as SongPreview).setupSongPreview();
+            }
+
+            if (_gvars.options.replay.isLoaded)
+            {
+                // Setup Vars
+                _gvars.songQueue = [];
+                _gvars.songQueue.push(Playlist.instance.getSong(_gvars.options.replay.level));
+
+                // Switch to game
+                _gvars.gameMain.addAlert("Playing chart preview...");
+                switchTo(Main.GAME_PLAY_PANEL);
             }
         }
 

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -886,7 +886,6 @@ package menu
             }
             _gvars.options.replay = new SongPreview((e.contextMenuOwner as SongItem).level);
             _gvars.options.loadPreview = true;
-            _gvars.replayHistory.push(_gvars.options.replay);
 
             if (!_gvars.options.replay.isLoaded)
             {


### PR DESCRIPTION
Closes #170.

New features:
- A new button has been added into the context menus of song items that allows previewing their charts.

Bug fixes:
- Memory leaks concerning loader listeners in the `Replay` class have been removed.
- If a chart preview has been previously played, upon reloading or switching a user, the preview would be played again. This behaviour is avoided.