### PR TITLE
Gameplay bug fixes

### DIFF
--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -57,6 +57,14 @@ package arc.mp
                 connection.mode = Multiplayer.GAME_R3;
                 connection.connect();
             }
+            else
+            {
+                textLogin = new Text("Please Login or Register");
+                textLogin.x = Main.GAME_WIDTH / 2 - textLogin.width / 2;
+                textLogin.y = Main.GAME_HEIGHT / 2 - textLogin.height * 3 / 2;
+                addChild(textLogin);
+                return;
+            }
 
             Style.fontSize = ArcGlobals.instance.configMPSize;
 
@@ -185,15 +193,6 @@ package arc.mp
                 }
             });
 
-            if (GlobalVariables.instance.activeUser.isGuest || GlobalVariables.instance.activeUser.id == 2)
-            {
-                textLogin = new Text("Please Login or Register");
-                textLogin.x = Main.GAME_WIDTH / 2 - textLogin.width / 2;
-                textLogin.y = Main.GAME_HEIGHT / 2 - textLogin.height * 3 / 2;
-                addChild(textLogin);
-                return;
-            }
-
             buttonMP = new BoxButton(130, 25, "Connect");
             buttonMP.x = 5;
             buttonMP.y = Main.GAME_HEIGHT - 30;
@@ -271,7 +270,6 @@ package arc.mp
                 }
             });
         }
-
 
         public function buildContextMenu():void
         {
@@ -405,7 +403,8 @@ package arc.mp
             }
             if (textLogin != null)
                 textLogin.visible = show;
-            window.visible = show;
+            if (window != null)
+                window.visible = show;
         }
 
         private function foreachroom(foreach:Function):void
@@ -463,14 +462,20 @@ package arc.mp
 
         private function showThrobber():void
         {
-            throbber.visible = true;
-            throbber.start();
+            if (throbber != null)
+            {
+                throbber.visible = true;
+                throbber.start();
+            }
         }
 
         private function hideThrobber():void
         {
-            throbber.visible = false;
-            throbber.stop();
+            if (throbber != null)
+            {
+                throbber.visible = false;
+                throbber.stop();
+            }
         }
     }
 }

--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -1,35 +1,27 @@
 package arc.mp
 {
-    import Main;
-    import menu.MenuPanel;
-    import classes.Text;
-    import classes.BoxButton;
-
     import arc.ArcGlobals;
     import arc.mp.ListItemDoubleClick;
-    import arc.mp.MultiplayerPrompt;
     import arc.mp.MultiplayerChat;
+    import arc.mp.MultiplayerPrompt;
     import arc.mp.MultiplayerUsers;
-    import com.flashfla.net.Multiplayer;
-
-    import flash.ui.Keyboard;
-    import flash.ui.ContextMenu;
-    import flash.ui.ContextMenuItem;
-    import flash.events.ContextMenuEvent;
-    import flash.utils.Timer;
-    import flash.events.TimerEvent;
-    import flash.events.Event;
-    import flash.events.MouseEvent;
-    import flash.display.Sprite;
-
+    import classes.BoxButton;
+    import classes.Text;
     import com.bit101.components.List;
     import com.bit101.components.PushButton;
     import com.bit101.components.Style;
     import com.bit101.components.Window;
-
     import com.flashfla.components.Throbber;
-
+    import com.flashfla.net.Multiplayer;
+    import flash.events.ContextMenuEvent;
+    import flash.events.Event;
+    import flash.events.MouseEvent;
+    import flash.events.TimerEvent;
+    import flash.ui.ContextMenu;
+    import flash.ui.ContextMenuItem;
+    import flash.utils.Timer;
     import it.gotoandplay.smartfoxserver.SFSEvent;
+    import menu.MenuPanel;
 
     public class MultiplayerPanel extends MenuPanel
     {
@@ -80,8 +72,11 @@ package arc.mp
             controlRooms.setSize(200, 350);
             controlRooms.addEventListener(MouseEvent.DOUBLE_CLICK, function(event:MouseEvent):void
             {
-                var room:Object = controlRooms.selectedItem.data;
-                joinRoom(room, room.playerCount < room.maxPlayerCount);
+                if (controlRooms.selectedItem != null && controlRooms.selectedItem.data != null)
+                {
+                    var room:Object = controlRooms.selectedItem.data;
+                    joinRoom(room, room.playerCount < room.maxPlayerCount);
+                }
             });
             window.addChild(controlRooms);
             buildContextMenu();
@@ -391,7 +386,7 @@ package arc.mp
         {
             if (button == null)
                 return;
-            
+
             if (button.parent == null && show)
                 addChild(button);
             else if (button.parent == this && !show)

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -179,6 +179,17 @@ package game
         {
             options = _gvars.options;
             song = options.song;
+            if (!options.isEditor && song.chart.Notes.length == 0)
+            {
+                _gvars.gameMain.addAlert("Chart has no notes, returning to main menu...", 120, Alert.RED);
+                var screen:int = _gvars.activeUser.startUpScreen;
+                if (!_gvars.activeUser.isGuest && (screen == 0 || screen == 1) && !MultiplayerSingleton.getInstance().connection.connected)
+                {
+                    MultiplayerSingleton.getInstance().connection.connect();
+                }
+                switchTo(Main.GAME_MENU_PANEL);
+                return false;
+            }
 
             // --- Per Song Options - Super hacky, but actually solid
             if (_gvars.sql_connect && !options.isEditor && !options.replay)
@@ -435,7 +446,7 @@ package game
             noteBox.position();
             this.addChild(noteBox);
 
-            if (MultiplayerSingleton.getInstance().connection.connected && !MultiplayerSingleton.getInstance().isInRoom())
+            if (!options.isEditor && MultiplayerSingleton.getInstance().connection.connected && !MultiplayerSingleton.getInstance().isInRoom())
             {
                 var isInSoloMode:Boolean = true;
                 MultiplayerSingleton.getInstance().connection.disconnect(isInSoloMode);
@@ -1374,7 +1385,7 @@ package game
             GAME_STATE = GAME_DISPOSE;
 
             var screen:int = _gvars.activeUser.startUpScreen;
-            if (screen == 0 || screen == 1)
+            if (!_gvars.activeUser.isGuest == false && (screen == 0 || screen == 1) && !MultiplayerSingleton.getInstance().connection.connected)
             {
                 MultiplayerSingleton.getInstance().connection.connect();
             }

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -1385,7 +1385,7 @@ package game
             GAME_STATE = GAME_DISPOSE;
 
             var screen:int = _gvars.activeUser.startUpScreen;
-            if (!_gvars.activeUser.isGuest == false && (screen == 0 || screen == 1) && !MultiplayerSingleton.getInstance().connection.connected)
+            if (!_gvars.activeUser.isGuest && (screen == 0 || screen == 1) && !MultiplayerSingleton.getInstance().connection.connected)
             {
                 MultiplayerSingleton.getInstance().connection.connect();
             }

--- a/src/popups/PopupContextMenu.as
+++ b/src/popups/PopupContextMenu.as
@@ -160,6 +160,7 @@ package popups
             }
             else if (e.target.action == "reload_engine")
             {
+                MultiplayerSingleton.destroyInstance();
                 Flags.VALUES = {};
                 _gvars.gameMain.switchTo("none");
             }


### PR DESCRIPTION
Bugs fixed:
- When a chart with no notes is being played, the game would softlock, and the player would have to manually press the quit button to exit gameplay. A check has been added so that gameplay would not proceed when such chart is being played.
- Unnecessary connects and disconnects to and from the MP server are now avoided. Extraneous error messages regarding MP login fails should no longer appear.
- Fixed a crash that occurs when double-clicking an empty room in the multiplayer panel.
- Fixed a crash when `showThrobber()` and `hideThrobber()` are called with `throbber` being `null`.
- When you play as guest, click the 'Reload Engine/User' button, and then login, you cannot get connected to MP. To fix this, we destroy the MP connection every time the engine is reloaded.
- Added a very minor MP optimization.