### PR TITLE
Fix Race condition for SQL Connection

### DIFF
--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -50,6 +50,8 @@ package
         private var _loader:DynamicURLLoader;
 
         ///- Constants
+        public static const DB_CONNECT_COMPLETE:String = "DBLoadComplete";
+        public static const DB_CONNECT_ERROR:String = "DBLoadError";
         public static const LOAD_COMPLETE:String = "LoadComplete";
         public static const LOAD_ERROR:String = "LoadError";
         public static const HIGHSCORES_LOAD_COMPLETE:String = "HighscoresLoadComplete";
@@ -158,22 +160,24 @@ package
             sql_conn.addEventListener(SQLErrorEvent.ERROR, sql_errorHandler);
 
             sql_conn.openAsync(sql_db);
+        }
 
-            function sql_openHandler(event:SQLEvent):void
-            {
-                sql_connect = true;
+        private function sql_openHandler(event:SQLEvent):void
+        {
+            sql_connect = true;
 
-                trace("Database was connected successfully");
+            trace("Database was connected successfully");
 
-                SQLQueries.refreshStatements(sql_conn);
-            }
+            SQLQueries.refreshStatements(sql_conn);
+            this.dispatchEvent(new Event(DB_CONNECT_COMPLETE));
+        }
 
-            function sql_errorHandler(event:SQLErrorEvent):void
-            {
-                sql_connect = false;
-                trace("Error message:", event.error.message);
-                trace("Details:", event.error.details);
-            }
+        private function sql_errorHandler(event:SQLErrorEvent):void
+        {
+            sql_connect = false;
+            trace("Error message:", event.error.message);
+            trace("Details:", event.error.details);
+            this.dispatchEvent(new Event(DB_CONNECT_ERROR));
         }
 
         public function websocketPortNumber(type:String):uint

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -100,6 +100,7 @@ package menu
 
         private var songItemContextMenu:ContextMenu;
         private var songItemContextMenuItem:ContextMenuItem;
+        private var songItemSongOptionsContext:ContextMenuItem;
         private var songItemRemoveQueueContext:ContextMenuItem;
 
         public static var previewMusic:SongPlayerBytes;
@@ -112,6 +113,9 @@ package menu
 
         override public function init():Boolean
         {
+            // Listen for DB Connection
+            _gvars.addEventListener(GlobalVariables.DB_CONNECT_COMPLETE, e_sqlConnectComplete);
+
             // Load Default Alt Engine
             if (_avars.legacyDefaultEngine && !Flags.VALUES[Flags.LEGACY_ENGINE_DEFAULT_LOAD])
             {
@@ -155,12 +159,10 @@ package menu
             songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_playChartPreviewContextSelect);
             songItemContextMenu.customItems.push(songItemContextMenuItem);
 
-            if (_gvars.sql_connect)
-            {
-                songItemContextMenuItem = new ContextMenuItem("Song Options");
-                songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_songOptionsContextSelect);
-                songItemContextMenu.customItems.push(songItemContextMenuItem);
-            }
+            songItemSongOptionsContext = new ContextMenuItem("Song Options");
+            songItemSongOptionsContext.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_songOptionsContextSelect);
+            songItemSongOptionsContext.visible = _gvars.sql_connect;
+            songItemContextMenu.customItems.push(songItemSongOptionsContext);
 
             songItemRemoveQueueContext = new ContextMenuItem("Remove from Queue");
             songItemRemoveQueueContext.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_removeFromQueueContextSelect);
@@ -340,6 +342,8 @@ package menu
 
         override public function stageRemove():void
         {
+            _gvars.removeEventListener(GlobalVariables.DB_CONNECT_COMPLETE, e_sqlConnectComplete);
+
             //- Remove Listeners
             if (stage)
                 stage.removeEventListener(KeyboardEvent.KEY_DOWN, keyHandler);
@@ -1718,6 +1722,16 @@ package menu
         //******************************************************************************************//
         // Event Handlers
         //******************************************************************************************//
+
+        /**
+         * Called when the SQL Local DB is connected.
+         * @param event
+         */
+        private function e_sqlConnectComplete(event:Object):void
+        {
+            _gvars.removeEventListener(GlobalVariables.DB_CONNECT_COMPLETE, e_sqlConnectComplete);
+            songItemSongOptionsContext.visible = _gvars.sql_connect; // Race Condition
+        }
 
         /**
          * General Click Handler for multiple objects.


### PR DESCRIPTION
Song Options context menu doesn't always show up when first coming from the login/game loading screen because it's connection is async. But after a song result, the it's already connected so it appears normally.
Fix is just adding a event listener to the connection and toggling the visibility of the menu item instead of add/removing it.