### PR TITLE
Fix canon playlist not being cleared on engine reload.

### DIFF
--- a/src/classes/Playlist.as
+++ b/src/classes/Playlist.as
@@ -142,7 +142,7 @@ package classes
             playList = new Array();
             indexList = new Array();
 
-            if (_instanceCanon == null)
+            if (_instanceCanon == null && !legacy)
             {
                 _instanceCanon = new Playlist();
                 _instanceCanon._isLoaded = true;

--- a/src/popups/PopupContextMenu.as
+++ b/src/popups/PopupContextMenu.as
@@ -12,6 +12,7 @@ package popups
 
     import menu.MenuPanel;
     import arc.mp.MultiplayerSingleton;
+    import classes.Playlist;
 
     public class PopupContextMenu extends MenuPanel
     {
@@ -162,6 +163,7 @@ package popups
             {
                 MultiplayerSingleton.destroyInstance();
                 Flags.VALUES = {};
+                Playlist.clearCanon();
                 _gvars.gameMain.switchTo("none");
             }
             else if (e.target.action == "switch_profile")
@@ -169,7 +171,7 @@ package popups
                 MultiplayerSingleton.destroyInstance();
                 Flags.VALUES = {};
                 _gvars.playerUser.refreshUser();
-                _gvars.gameMain.switchTo("GameLoginPanel");
+                _gvars.gameMain.switchTo(Main.GAME_LOGIN_PANEL);
             }
         }
     }


### PR DESCRIPTION
It wasn't. It should've. It's fixed.

Playlist would display the first loaded instance of the playlist regardless if the playlist was refreshed or not.