### PR TITLE
Add vsync build flag to help with Hybrid Builds.

### DIFF
--- a/asconfig.json
+++ b/asconfig.json
@@ -28,6 +28,10 @@
                 "value": false
             },
             {
+                "name": "CONFIG::vsync",
+                "value": true
+            },
+            {
                 "name": "CONFIG::timeStamp",
                 "value": "\"9999-12-31\""
             },

--- a/src/Main.as
+++ b/src/Main.as
@@ -35,7 +35,6 @@ package
     import flash.events.Event;
     import flash.events.KeyboardEvent;
     import flash.events.MouseEvent;
-    import flash.events.VsyncStateChangeAvailabilityEvent;
     import flash.system.Capabilities;
     import flash.text.AntiAliasType;
     import flash.text.TextField;
@@ -50,6 +49,11 @@ package
     import popups.PopupHelp;
     import popups.PopupOptions;
     import popups.PopupReplayHistory;
+
+    CONFIG::vsync
+    {
+        import flash.events.VsyncStateChangeAvailabilityEvent;
+    }
 
     public class Main extends MenuPanel
     {
@@ -107,7 +111,10 @@ package
             if (stage)
             {
                 //- Set up vSync
-                stage.addEventListener(VsyncStateChangeAvailabilityEvent.VSYNC_STATE_CHANGE_AVAILABILITY, onVsyncStateChangeAvailability);
+                CONFIG::vsync
+                {
+                    stage.addEventListener(VsyncStateChangeAvailabilityEvent.VSYNC_STATE_CHANGE_AVAILABILITY, onVsyncStateChangeAvailability);
+                }
 
                 gameInit();
             }
@@ -117,6 +124,7 @@ package
             }
         }
 
+        CONFIG::vsync
         public function onVsyncStateChangeAvailability(event:VsyncStateChangeAvailabilityEvent):void
         {
             if (event.available)

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -1109,18 +1109,21 @@ package popups
                 box.addChild(useCacheCheckbox);
                 yOff += 30;
 
-                var useVSyncCheckboxText:Text = new Text(_lang.string("air_options_use_vsync"));
-                useVSyncCheckboxText.x = xOff + 22;
-                useVSyncCheckboxText.y = yOff;
-                box.addChild(useVSyncCheckboxText);
-                yOff += 2;
+                CONFIG::vsync
+                {
+                    var useVSyncCheckboxText:Text = new Text(_lang.string("air_options_use_vsync"));
+                    useVSyncCheckboxText.x = xOff + 22;
+                    useVSyncCheckboxText.y = yOff;
+                    box.addChild(useVSyncCheckboxText);
+                    yOff += 2;
 
-                useVSyncCheckbox = new BoxCheck();
-                useVSyncCheckbox.x = xOff + 2;
-                useVSyncCheckbox.y = yOff;
-                useVSyncCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
-                box.addChild(useVSyncCheckbox);
-                yOff += 30;
+                    useVSyncCheckbox = new BoxCheck();
+                    useVSyncCheckbox.x = xOff + 2;
+                    useVSyncCheckbox.y = yOff;
+                    useVSyncCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
+                    box.addChild(useVSyncCheckbox);
+                    yOff += 30;
+                }
 
                 var useWebsocketCheckboxText:Text = new Text(_lang.string("air_options_use_websockets"));
                 useWebsocketCheckboxText.x = xOff + 22;
@@ -1788,10 +1791,13 @@ package popups
             //- Vsync Toggle
             else if (e.target == useVSyncCheckbox)
             {
-                _gvars.air_useVSync = !_gvars.air_useVSync;
-                LocalStore.setVariable("air_useVSync", _gvars.air_useVSync);
-                stage.vsyncEnabled = _gvars.air_useVSync;
-                _gvars.gameMain.addAlert("Set VSYNC: " + stage.vsyncEnabled, 120, Alert.RED);
+                CONFIG::vsync
+                {
+                    _gvars.air_useVSync = !_gvars.air_useVSync;
+                    LocalStore.setVariable("air_useVSync", _gvars.air_useVSync);
+                    stage.vsyncEnabled = _gvars.air_useVSync;
+                    _gvars.gameMain.addAlert("Set VSYNC: " + stage.vsyncEnabled, 120, Alert.RED);
+                }
             }
 
             // Use HTTP Websockets
@@ -2104,8 +2110,11 @@ package popups
 
                 autoSaveLocalCheckbox.checked = _gvars.air_autoSaveLocalReplays;
                 useCacheCheckbox.checked = _gvars.air_useLocalFileCache;
-                useVSyncCheckbox.checked = _gvars.air_useVSync;
                 useWebsocketCheckbox.checked = _gvars.air_useWebsockets;
+                CONFIG::vsync
+                {
+                    useVSyncCheckbox.checked = _gvars.air_useVSync;
+                }
 
                 var flipGraph:Boolean = LocalStore.getVariable("result_flip_graph", false);
                 flipGraphCheckbox.checked = flipGraph;


### PR DESCRIPTION
Air 26 doesn't support vsync, which was added in Air 31. This provides a compiler flag to exclude vsync features so older 0.0.8 style builds can be more easily compiled.

The `useVSyncCheckbox` variable is intentionally left in the `PopupOptions` as it produces cleaner code without affecting anything.