### PR TITLE
Prevent crash after playing chart with only 1 note

### DIFF
--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -590,11 +590,13 @@ package game
 
         private function initPlayerVars():void
         {
-            // Force no Judge on SongPreviews
+            // Force no judge, global and isolation offsets on SongPreviews
             if (options.replay && options.replay is SongPreview)
             {
                 options.offsetJudge = 0;
                 options.offsetGlobal = 0;
+                options.isolationLength = 0;
+                options.isolationOffset = 0;
             }
 
             reverseMod = options.modEnabled("reverse");

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -590,7 +590,7 @@ package game
 
         private function initPlayerVars():void
         {
-            // Force no judge, global and isolation offsets on SongPreviews
+            // Force no Judge on SongPreviews
             if (options.replay && options.replay is SongPreview)
             {
                 options.offsetJudge = 0;

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -595,8 +595,6 @@ package game
             {
                 options.offsetJudge = 0;
                 options.offsetGlobal = 0;
-                options.isolationLength = 0;
-                options.isolationOffset = 0;
             }
 
             reverseMod = options.modEnabled("reverse");

--- a/src/game/graph/GraphAccuracy.as
+++ b/src/game/graph/GraphAccuracy.as
@@ -391,7 +391,7 @@ package game.graph
 
             // Boos
             var boo:Object; // Variables: d, t, i
-            ratio_x = graphWidth / result.song.getNote(Math.max(1, song_arrows - 1)).time;
+            ratio_x = graphWidth / result.song.getNote(song_arrows - 1).time;
             for (i = 0; i < result.replay_bin_boos.length; i++)
             {
                 boo = result.replay_bin_boos[i];
@@ -412,6 +412,5 @@ package game.graph
             draw();
             drawOverlay(overlay.stage.mouseX - overlay.x, overlay.stage.mouseY - overlay.y);
         }
-
     }
 }

--- a/src/game/graph/GraphAccuracy.as
+++ b/src/game/graph/GraphAccuracy.as
@@ -391,7 +391,7 @@ package game.graph
 
             // Boos
             var boo:Object; // Variables: d, t, i
-            ratio_x = graphWidth / result.song.getNote(song_arrows - 1).time;
+            ratio_x = graphWidth / result.song.getNote(Math.max(0, song_arrows - 1)).time;
             for (i = 0; i < result.replay_bin_boos.length; i++)
             {
                 boo = result.replay_bin_boos[i];

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -292,10 +292,10 @@ package menu
                 pane.x = 155; // 332
                 pane.y = 64;
                 pane.graphics.lineStyle(1, 0xFFFFFF, 0.35, false);
-                pane.graphics.moveTo(0, 0);
-                pane.graphics.lineTo(401, 0);
-                pane.graphics.moveTo(0, 350);
-                pane.graphics.lineTo(401, 350);
+                pane.graphics.moveTo(0.2, -0.5);
+                pane.graphics.lineTo(399, -0.5);
+                pane.graphics.moveTo(0.2, 351.5);
+                pane.graphics.lineTo(399, 351.5);
                 pane.addEventListener(MouseEvent.CLICK, songItemClicked, false, 0, true);
                 pane.addEventListener(MouseEvent.MOUSE_WHEEL, mouseWheelHandler, false, 0, true);
                 this.addChild(pane);

--- a/src/menu/MenuTokens.as
+++ b/src/menu/MenuTokens.as
@@ -63,9 +63,10 @@ package menu
             pane.y = 64;
             var border:Sprite = new Sprite();
             border.graphics.lineStyle(1, 0xFFFFFF, 1, true);
-            border.graphics.lineTo(578, 0);
-            border.graphics.moveTo(0, 357);
-            border.graphics.lineTo(578, 357);
+            border.graphics.moveTo(0.3, -0.5);
+            border.graphics.lineTo(577, -0.5);
+            border.graphics.moveTo(0.3, 358.5);
+            border.graphics.lineTo(577, 358.5);
             border.alpha = 0.35;
             pane.addChild(border);
             this.addChild(pane);

--- a/src/menu/SongItem.as
+++ b/src/menu/SongItem.as
@@ -73,7 +73,7 @@ package menu
             if (!isLocked)
             {
                 this.graphics.moveTo(32, 0);
-                this.graphics.lineTo(32, height);
+                this.graphics.lineTo(32, height - 1);
             }
         }
 


### PR DESCRIPTION
Bug fixes:
- The isolation offset and notecount is set to 0 when previewing a chart.
- A null error crash is prevented when displaying the accuracy graph of a chart with only 1 note.

Aesthetic changes:
- Prevent the difficulty dividers of SongItems from jutting out
- Fit borders with scrollpanes in MenuSongSelection and MenuTokens better. This change is not apparent with the game window at its default size, but it's more obvious when it's fullscreen.