### PR TITLE
Rewrite Song Options

### DIFF
--- a/assets/icons.fla
+++ b/assets/icons.fla
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d64e3aac9ba387528d7017a55ea86a0da247b633b77cc2924255431cee506bb
-size 226496
+oid sha256:d65cdc973a18b2ef475988edb91c7a01278f7b7e18cc35c117aed2f37c959b74
+size 236865

--- a/libs/assets/icons.swc
+++ b/libs/assets/icons.swc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d4eaf54607de9f2b8c2e548679a7fb9da8cfac645cf93eba80ca3593ef6d7a1
-size 8188
+oid sha256:6a139db734a62eb88ec27e30c3ac60853931eb0d66f2f2dda204ab741ba184b9
+size 9291

--- a/src/AirContext.as
+++ b/src/AirContext.as
@@ -146,6 +146,37 @@ package
             return null;
         }
 
+        static public function readTextFile(file:File, errorCallback:Function = null):String
+        {
+            if (file.exists)
+            {
+                var fileStream:FileStream = new FileStream();
+                fileStream.addEventListener(SecurityErrorEvent.SECURITY_ERROR, (errorCallback != null ? errorCallback : e_fileError));
+                fileStream.addEventListener(IOErrorEvent.IO_ERROR, (errorCallback != null ? errorCallback : e_fileError));
+                fileStream.open(file, FileMode.READ);
+                var data:String = fileStream.readUTFBytes(fileStream.bytesAvailable);
+                fileStream.close();
+
+                return data;
+            }
+            return null;
+        }
+
+        static public function writeTextFile(file:File, data:String, errorCallback:Function = null):File
+        {
+            if (data == null || data.length == 0)
+                return file;
+
+            var fileStream:FileStream = new FileStream();
+            fileStream.addEventListener(SecurityErrorEvent.SECURITY_ERROR, (errorCallback != null ? errorCallback : e_fileError));
+            fileStream.addEventListener(IOErrorEvent.IO_ERROR, (errorCallback != null ? errorCallback : e_fileError));
+            fileStream.open(file, FileMode.WRITE);
+            fileStream.writeUTFBytes(data);
+            fileStream.close();
+
+            return file;
+        }
+
         static public function deleteFile(appPath:String):Boolean
         {
             var cacheFile:File = new File(appPath);

--- a/src/Main.as
+++ b/src/Main.as
@@ -456,7 +456,7 @@ package
                     this.removeEventListener(Event.ENTER_FRAME, updatePreloader);
                     _playlist.updateSongAccess();
                     _playlist.updatePublicSongsCount();
-                    _gvars.initSQLConnection();
+                    _gvars.loadUserSongData();
                     switchTo(_gvars.activeUser.isGuest || _gvars.flashvars["__forceLogin"] ? GAME_LOGIN_PANEL : GAME_MENU_PANEL);
                 }
             }

--- a/src/SQLQueries.as
+++ b/src/SQLQueries.as
@@ -199,7 +199,8 @@ package
                 }
 
                 sql_conn.close();
-                callback(out);
+                if (callback != null)
+                    callback(out);
             }
         }
     }

--- a/src/SQLQueries.as
+++ b/src/SQLQueries.as
@@ -68,7 +68,7 @@ package
         }
 
         /**
-         * Gets a songs details or null if none found.
+         * Returns the Song Details for the given song and engine, or null if missing.
          * @param engine_id
          * @param level_id
          * @return
@@ -83,7 +83,7 @@ package
 
         /**
          * Safe version of the getSongDetails that only returns a SQLSongDetails.
-         * This also creates the entires in in the song details and engine objects.
+         * This also creates the entries in the song details and engine objects.
          * @param engine_id
          * @param level_id
          * @return

--- a/src/classes/MouseTooltip.as
+++ b/src/classes/MouseTooltip.as
@@ -15,7 +15,6 @@ package classes
             this.mouseEnabled = false;
             this.mouseChildren = false;
 
-            super();
             msg = new TextField();
             msg.x = 5;
             msg.selectable = false;
@@ -44,11 +43,16 @@ package classes
                     msg.multiline = true;
                     msg.width = maxWidth - 10;
                 }
+
                 this.graphics.clear();
-                this.graphics.lineStyle(1, 0xffffff, 0.75);
-                this.graphics.beginFill(GameBackgroundColor.BG_DARK, 0.95);
-                this.graphics.drawRect(0, 0, msg.width + 10, msg.height + 2);
-                this.graphics.endFill();
+
+                if (msg.textWidth > 0)
+                {
+                    this.graphics.lineStyle(1, 0xffffff, 0.75);
+                    this.graphics.beginFill(GameBackgroundColor.BG_DARK, 0.95);
+                    this.graphics.drawRect(0, 0, msg.width + 10, msg.height + 2);
+                    this.graphics.endFill();
+                }
             }
         }
 

--- a/src/classes/MouseTooltip.as
+++ b/src/classes/MouseTooltip.as
@@ -33,22 +33,28 @@ package classes
 
         public function set message(value:String):void
         {
-            msg.wordWrap = false;
-            msg.multiline = false;
-            msg.htmlText = value;
-            if (msg.width > maxWidth)
+            if (value != msg.htmlText)
             {
-                msg.wordWrap = true;
-                msg.multiline = true;
-                msg.width = maxWidth;
+                msg.wordWrap = false;
+                msg.multiline = false;
+                msg.htmlText = value;
+                if (msg.width > maxWidth)
+                {
+                    msg.wordWrap = true;
+                    msg.multiline = true;
+                    msg.width = maxWidth - 10;
+                }
+                this.graphics.clear();
+                this.graphics.lineStyle(1, 0xffffff, 0.75);
+                this.graphics.beginFill(GameBackgroundColor.BG_DARK, 0.95);
+                this.graphics.drawRect(0, 0, msg.width + 10, msg.height + 2);
+                this.graphics.endFill();
             }
-            this.graphics.clear();
-            this.graphics.lineStyle(1, 0xffffff, 0.75);
-            this.graphics.beginFill(GameBackgroundColor.BG_DARK, 0.95);
-            this.graphics.drawRect(0, 0, msg.width + 10, msg.height + 2);
-            this.graphics.endFill();
         }
 
+        public function get message():String
+        {
+            return msg.htmlText;
+        }
     }
-
 }

--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -70,6 +70,7 @@ package classes
 
         public var DISPLAY_LEGACY_SONGS:Boolean = false;
         public var DISPLAY_SONG_FLAG:Boolean = true;
+        public var DISPLAY_SONG_NOTE:Boolean = true;
 
         //- Game Data
         public var GLOBAL_OFFSET:Number = 0;
@@ -444,6 +445,8 @@ package classes
                 this.AUTO_JUDGE_OFFSET = _settings.autoJudgeOffset;
             if (_settings.viewSongFlag != null)
                 this.DISPLAY_SONG_FLAG = _settings.viewSongFlag;
+            if (_settings.viewSongNote != null)
+                this.DISPLAY_SONG_NOTE = _settings.viewSongNote;
             if (_settings.viewJudge != null)
                 this.DISPLAY_JUDGE = _settings.viewJudge;
             if (_settings.viewJudgeAnimations != null)
@@ -583,6 +586,7 @@ package classes
             gameSave.judgeOffset = this.JUDGE_OFFSET;
             gameSave.autoJudgeOffset = this.AUTO_JUDGE_OFFSET;
             gameSave.viewSongFlag = this.DISPLAY_SONG_FLAG;
+            gameSave.viewSongNote = this.DISPLAY_SONG_NOTE;
             gameSave.viewJudge = this.DISPLAY_JUDGE;
             gameSave.viewHealth = this.DISPLAY_HEALTH;
             gameSave.viewJudgeAnimations = this.DISPLAY_JUDGE_ANIMATIONS;

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -203,39 +203,27 @@ package game
                 return false;
             }
 
-            // --- Per Song Options - Super hacky, but actually solid
-            if (_gvars.sql_connect && !options.isEditor && !options.replay)
+            // --- Per Song Options
+            var perSongOptions:SQLSongDetails = SQLQueries.getSongDetails((song.entry.engine != null ? song.entry.engine.id : Constant.BRAND_NAME_SHORT_LOWER()), song.entry.level);
+            if (perSongOptions != null && !options.isEditor && !options.replay)
             {
                 options.fill(); // Reset
-                SQLQueries.getSongDetails(_gvars.sql_conn, {"engine": (song.entry.engine != null ? song.entry.engine : Constant.BRAND_NAME_SHORT_LOWER()), "song_id": song.entry.level}, function(results:Vector.<SQLSongDetails>):void
+
+                // Custom Offsets
+                if (perSongOptions.set_custom_offsets)
                 {
-                    //trace("Delay Gameplay init for:", song.entry.level);
-                    if (results != null && results.length > 0)
-                    {
-                        var result:SQLSongDetails = results[0];
+                    options.offsetJudge = perSongOptions.offset_judge;
+                    options.offsetGlobal = perSongOptions.offset_music;
+                }
 
-                        // Custom Offsets
-                        if (result.set_custom_offsets)
-                        {
-                            options.offsetJudge = result.offset_judge;
-                            options.offsetGlobal = result.offset_music;
-                        }
-
-                        // Invert Mirror Mod
-                        if (result.set_mirror_invert)
-                        {
-                            if (options.modEnabled("mirror"))
-                                delete options.modCache["mirror"];
-                            else
-                                options.modCache["mirror"] = true;
-                        }
-                    }
-
-                    stageAdd(); // This is cancelled by returning false below.
-                });
-
-                initBackground();
-                return false; // Cancel stageAdd, will be called when callback is complete.
+                // Invert Mirror Mod
+                if (perSongOptions.set_mirror_invert)
+                {
+                    if (options.modEnabled("mirror"))
+                        delete options.modCache["mirror"];
+                    else
+                        options.modCache["mirror"] = true;
+                }
             }
             // --- End Per Song Settings
 

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -105,8 +105,6 @@ package menu
         public static var options:MenuSongSelectionOptions = new MenuSongSelectionOptions();
 
         private var songItemContextMenu:ContextMenu;
-        private var songItemContextMenuItem:ContextMenuItem;
-        private var songItemSongOptionsContext:ContextMenuItem;
         private var songItemRemoveQueueContext:ContextMenuItem;
 
         public static var previewMusic:SongPlayerBytes;
@@ -149,24 +147,26 @@ package menu
             GENRE_MODE = LocalStore.getVariable("genre_mode", GENRE_DIFFICULTIES);
 
             // Menu Music Context Menu
+            var songItemContextMenuItem:ContextMenuItem;
+
             songItemContextMenu = new ContextMenu();
-            songItemContextMenuItem = new ContextMenuItem("Set as Menu Music");
+            songItemContextMenuItem = new ContextMenuItem(_lang.stringSimple("song_selection_context_menu_music"));
             songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_setAsMenuMusicContextSelect);
             songItemContextMenu.customItems.push(songItemContextMenuItem);
 
-            songItemContextMenuItem = new ContextMenuItem("Listen to Song Preview");
+            songItemContextMenuItem = new ContextMenuItem(_lang.stringSimple("song_selection_context_song_preview"), true);
             songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_listenToSongPreviewContextSelect);
             songItemContextMenu.customItems.push(songItemContextMenuItem);
 
-            songItemContextMenuItem = new ContextMenuItem("Play Chart Preview");
+            songItemContextMenuItem = new ContextMenuItem(_lang.stringSimple("song_selection_context_chart_preview"));
             songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_playChartPreviewContextSelect);
             songItemContextMenu.customItems.push(songItemContextMenuItem);
 
-            songItemSongOptionsContext = new ContextMenuItem("Song Options");
-            songItemSongOptionsContext.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_songOptionsContextSelect);
-            songItemContextMenu.customItems.push(songItemSongOptionsContext);
+            songItemContextMenuItem = new ContextMenuItem(_lang.stringSimple("song_selection_context_song_options"));
+            songItemContextMenuItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_songOptionsContextSelect);
+            songItemContextMenu.customItems.push(songItemContextMenuItem);
 
-            songItemRemoveQueueContext = new ContextMenuItem("Remove from Queue");
+            songItemRemoveQueueContext = new ContextMenuItem(_lang.stringSimple("song_selection_context_remove_from_queue"), true);
             songItemRemoveQueueContext.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_removeFromQueueContextSelect);
             songItemContextMenu.customItems.push(songItemRemoveQueueContext);
 
@@ -1315,7 +1315,7 @@ package menu
                 songQueueButton.x = 5;
                 songQueueButton.y = 256;
                 songQueueButton.level = songDetails.level;
-                songQueueButton.setHoverText(_lang.string("song_selection_song_panel_queue"));
+                songQueueButton.setHoverText(_lang.string("song_selection_song_panel_hover_queue"));
                 songQueueButton.addEventListener(MouseEvent.CLICK, songQueueClick, false, 0, true);
                 infoBox.addChild(songQueueButton);
 
@@ -1326,7 +1326,7 @@ package menu
                     songHighscoresButton.y = 256;
                     songHighscoresButton.level = songDetails.level;
                     songHighscoresButton.action = "highscores";
-                    songHighscoresButton.setHoverText((options.infoTab == TAB_HIGHSCORES ? _lang.string("song_selection_song_panel_info") : _lang.string("song_selection_song_panel_scores")));
+                    songHighscoresButton.setHoverText((options.infoTab == TAB_HIGHSCORES ? _lang.string("song_selection_song_panel_hover_info") : _lang.string("song_selection_song_panel_hover_scores")));
                     songHighscoresButton.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                     infoBox.addChild(songHighscoresButton);
                 }
@@ -1336,7 +1336,7 @@ package menu
                 songOptionsButton.y = 256;
                 songOptionsButton.level = songDetails.level;
                 songOptionsButton.action = "songOptions";
-                songOptionsButton.setHoverText("Song Options");
+                songOptionsButton.setHoverText(_lang.string("song_selection_song_panel_hover_song_options"));
                 songOptionsButton.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                 infoBox.addChild(songOptionsButton);
 

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -115,9 +115,6 @@ package menu
 
         override public function init():Boolean
         {
-            // Listen for DB Connection
-            _gvars.addEventListener(GlobalVariables.DB_CONNECT_COMPLETE, e_sqlConnectComplete);
-
             // Load Default Alt Engine
             if (_avars.legacyDefaultEngine && !Flags.VALUES[Flags.LEGACY_ENGINE_DEFAULT_LOAD])
             {
@@ -163,7 +160,6 @@ package menu
 
             songItemSongOptionsContext = new ContextMenuItem("Song Options");
             songItemSongOptionsContext.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, e_songOptionsContextSelect);
-            songItemSongOptionsContext.visible = _gvars.sql_connect;
             songItemContextMenu.customItems.push(songItemSongOptionsContext);
 
             songItemRemoveQueueContext = new ContextMenuItem("Remove from Queue");
@@ -332,8 +328,6 @@ package menu
 
         override public function stageRemove():void
         {
-            _gvars.removeEventListener(GlobalVariables.DB_CONNECT_COMPLETE, e_sqlConnectComplete);
-
             //- Remove Listeners
             if (stage)
                 stage.removeEventListener(KeyboardEvent.KEY_DOWN, keyHandler);
@@ -1708,16 +1702,6 @@ package menu
         //******************************************************************************************//
         // Event Handlers
         //******************************************************************************************//
-
-        /**
-         * Called when the SQL Local DB is connected.
-         * @param event
-         */
-        private function e_sqlConnectComplete(event:Object):void
-        {
-            _gvars.removeEventListener(GlobalVariables.DB_CONNECT_COMPLETE, e_sqlConnectComplete);
-            songItemSongOptionsContext.visible = _gvars.sql_connect; // Race Condition
-        }
 
         /**
          * General Click Handler for multiple objects.

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -48,6 +48,10 @@ package menu
     import popups.PopupFilterManager;
     import popups.PopupQueueManager;
     import popups.PopupSongNotes;
+    import classes.BoxIcon;
+    import assets.menu.icons.fa.iconList;
+    import assets.menu.icons.fa.iconTrophy;
+    import assets.menu.icons.fa.iconGear;
 
     public class MenuSongSelection extends MenuPanel
     {
@@ -1304,30 +1308,42 @@ package menu
             if (accessLevel == GlobalVariables.SONG_ACCESS_PLAYABLE)
             {
                 var hasHighscores:Boolean = !songDetails.engine;
+                var buttonWidth:int = hasHighscores ? 51.5 : 79.5;
 
                 //- Make Display
-                var songQueueButton:BoxButton = new BoxButton(hasHighscores ? 79.5 : 164, 27, _lang.string("song_selection_song_panel_queue"), 12);
+                var songQueueButton:BoxIcon = new BoxIcon(buttonWidth, 27, new iconList());
                 songQueueButton.x = 5;
                 songQueueButton.y = 256;
                 songQueueButton.level = songDetails.level;
+                songQueueButton.setHoverText(_lang.string("song_selection_song_panel_queue"));
                 songQueueButton.addEventListener(MouseEvent.CLICK, songQueueClick, false, 0, true);
                 infoBox.addChild(songQueueButton);
 
                 if (hasHighscores)
                 {
-                    var songHighscoresButton:BoxButton = new BoxButton(79.5, 27, (options.infoTab == TAB_HIGHSCORES ? _lang.string("song_selection_song_panel_info") : _lang.string("song_selection_song_panel_scores")), 12);
-                    songHighscoresButton.x = 89.5;
+                    var songHighscoresButton:BoxIcon = new BoxIcon(buttonWidth, 27, new iconTrophy());
+                    songHighscoresButton.x = 5 + buttonWidth + 5;
                     songHighscoresButton.y = 256;
                     songHighscoresButton.level = songDetails.level;
                     songHighscoresButton.action = "highscores";
+                    songHighscoresButton.setHoverText((options.infoTab == TAB_HIGHSCORES ? _lang.string("song_selection_song_panel_info") : _lang.string("song_selection_song_panel_scores")));
                     songHighscoresButton.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                     infoBox.addChild(songHighscoresButton);
                 }
 
-                var songStartWidth:Number = 164;
+                var songOptionsButton:BoxIcon = new BoxIcon(buttonWidth, 27, new iconGear());
+                songOptionsButton.x = 5 + buttonWidth + 6 + (hasHighscores ? (buttonWidth + 5) : 0);
+                songOptionsButton.y = 256;
+                songOptionsButton.level = songDetails.level;
+                songOptionsButton.action = "songOptions";
+                songOptionsButton.setHoverText("Song Options");
+                songOptionsButton.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
+                infoBox.addChild(songOptionsButton);
+
+                buttonWidth = 164;
                 if (_mp.gameplayCanPick())
                 {
-                    songStartWidth = 79.5;
+                    buttonWidth = 79.5;
                     var songLoadButton:BoxButton = new BoxButton(79.5, 27, _lang.string("song_selection_song_panel_mp_load"), 14);
                     songLoadButton.x = 89.5;
                     songLoadButton.y = 288;
@@ -1335,7 +1351,7 @@ package menu
                     songLoadButton.addEventListener(MouseEvent.CLICK, songLoadClick, false, 0, true);
                     infoBox.addChild(songLoadButton);
                 }
-                var songStartButton:BoxButton = new BoxButton(songStartWidth, 27, _lang.string("song_selection_song_panel_play"), 14);
+                var songStartButton:BoxButton = new BoxButton(buttonWidth, 27, _lang.string("song_selection_song_panel_play"), 14);
                 songStartButton.x = 5;
                 songStartButton.y = 288;
                 songStartButton.level = songDetails.level;
@@ -1743,6 +1759,14 @@ package menu
                 {
                     options.infoTab = (options.infoTab == TAB_PLAYLIST ? TAB_HIGHSCORES : TAB_PLAYLIST);
                     buildInfoBox();
+                }
+                else if (clickAction == "songOptions")
+                {
+                    var songData:Object = _playlist.getSong(e.target.level);
+                    if (songData.error == null)
+                    {
+                        _gvars.gameMain.addPopup(new PopupSongNotes(this, songData));
+                    }
                 }
                 else if (clickAction == "clearQueue")
                 {

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -791,6 +791,18 @@ package menu
                 _mp.gameplayPicking(_playlist.getSong(options.activeSongID));
         }
 
+        public function updateSongItemNote(level:int):void
+        {
+            for (var i:int = 0; i < songItems.length; i++)
+            {
+                if (options.activeSongID == songItems[i].level)
+                {
+                    songItems[i].updateOrShow();
+                    break;
+                }
+            }
+        }
+
         /**
          * Called from the playlist scroll pane when a song item is clicked.
          * When a new song is selected, sets the active index and draws the info box for the new song information.

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -828,11 +828,6 @@ package menu
          */
         private function e_songOptionsContextSelect(e:ContextMenuEvent):void
         {
-            if (!_gvars.options)
-            {
-                _gvars.options = new GameOptions();
-                _gvars.options.fill();
-            }
             var songItem:SongItem = (e.contextMenuOwner as SongItem);
             var songData:Object = _playlist.getSong(songItem.level);
             if (songData.error == null)
@@ -849,11 +844,6 @@ package menu
          */
         private function e_setAsMenuMusicContextSelect(e:ContextMenuEvent):void
         {
-            if (!_gvars.options)
-            {
-                _gvars.options = new GameOptions();
-                _gvars.options.fill();
-            }
             var songItem:SongItem = (e.contextMenuOwner as SongItem);
             var songData:Object = _playlist.getSong(songItem.level);
             if (songData.error == null)
@@ -909,11 +899,6 @@ package menu
          */
         private function e_listenToSongPreviewContextSelect(e:ContextMenuEvent):void
         {
-            if (!_gvars.options)
-            {
-                _gvars.options = new GameOptions();
-                _gvars.options.fill();
-            }
             var songItem:SongItem = (e.contextMenuOwner as SongItem);
             var songData:Object = _playlist.getSong(songItem.level);
             if (songData.error == null)

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -791,18 +791,6 @@ package menu
                 _mp.gameplayPicking(_playlist.getSong(options.activeSongID));
         }
 
-        public function updateSongItemNote(level:int):void
-        {
-            for (var i:int = 0; i < songItems.length; i++)
-            {
-                if (options.activeSongID == songItems[i].level)
-                {
-                    songItems[i].updateOrShow();
-                    break;
-                }
-            }
-        }
-
         /**
          * Called from the playlist scroll pane when a song item is clicked.
          * When a new song is selected, sets the active index and draws the info box for the new song information.
@@ -954,6 +942,23 @@ package menu
         {
             options.queuePlaylist = _gvars.songQueue;
         }
+
+        /**
+         * Updates the displayed song note for the given level.
+         * @param level
+         */
+        public function updateSongItemNote(level:int):void
+        {
+            for (var i:int = 0; i < songItems.length; i++)
+            {
+                if (options.activeSongID == songItems[i].level)
+                {
+                    songItems[i].updateOrShow();
+                    break;
+                }
+            }
+        }
+
 
         //******************************************************************************************//
         // Info Box Logic

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -613,6 +613,7 @@ package menu
                 song = songList[sX];
                 sI = new SongItem();
                 sI.setData(song, _gvars.activeUser.getLevelRank(song));
+                sI.noteEnabled = _gvars.activeUser.DISPLAY_SONG_NOTE;
                 sI.setContextMenu(songItemContextMenu);
                 sI.y = yOffset;
                 sI.index = sX;

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -1275,7 +1275,8 @@ package menu
                 ratingDisplay.y = 5;
                 ratingDisplay.value = songDetails['song_rating'];
                 ratingDisplay.rotation = 90;
-                ratingDisplay.scaleX = ratingDisplay.scaleY = 0.60;
+                ratingDisplay.scaleX = ratingDisplay.scaleY = 0.50;
+                ratingDisplay.alpha = 0.2;
                 infoBox.addChild(ratingDisplay);
             }
             for (var item:String in infoDisplay)

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -1340,7 +1340,7 @@ package menu
 
                 if (hasHighscores)
                 {
-                    var songHighscoresButton:BoxIcon = new BoxIcon(buttonWidth, 27, new iconTrophy());
+                    var songHighscoresButton:BoxIcon = new BoxIcon(buttonWidth + 1, 27, new iconTrophy());
                     songHighscoresButton.x = 5 + buttonWidth + 5;
                     songHighscoresButton.y = 256;
                     songHighscoresButton.level = songDetails.level;

--- a/src/menu/SongItem.as
+++ b/src/menu/SongItem.as
@@ -1,22 +1,28 @@
 package menu
 {
-    import classes.Text;
-    import flash.display.Sprite;
-    import flash.display.GradientType;
-    import flash.events.MouseEvent;
-    import com.flashfla.utils.sprintf;
-    import com.flashfla.utils.NumberUtil;
     import classes.Language;
-    import flash.net.navigateToURL;
+    import classes.MouseTooltip;
+    import classes.Text;
+    import com.flashfla.utils.NumberUtil;
+    import com.flashfla.utils.sprintf;
+    import flash.display.GradientType;
+    import flash.display.Sprite;
+    import flash.events.Event;
+    import flash.events.MouseEvent;
+    import flash.events.TimerEvent;
+    import flash.geom.Point;
     import flash.net.URLRequest;
-    import flash.text.TextField;
+    import flash.net.navigateToURL;
     import flash.text.AntiAliasType;
+    import flash.text.TextField;
     import flash.text.TextFieldAutoSize;
     import flash.ui.ContextMenu;
-    import flash.events.Event;
+    import flash.utils.Timer;
+    import sql.SQLSongDetails;
 
     public class SongItem extends Sprite
     {
+        private static const HOVER_POINT_GLOBAL:Point = new Point();
         private static const GRADIENT_COLORS:Array = [0xFFFFFF, 0xFFFFFF];
         private static const GRADIENT_ALPHA_HIGHLIGHT:Array = [0.35, 0.1225];
         private static const GRADIENT_ALPHA:Array = [0.2, 0.04];
@@ -45,8 +51,15 @@ package menu
 
         // Song Data
         private var _songData:Object;
+        private var _songDetails:SQLSongDetails;
         private var _level:int = 0;
         public var isLocked:Boolean = false;
+
+        // Hover Data
+        private var _hoverTimer:Timer;
+        private var _hoverSprite:MouseTooltip;
+        private var _hoverTick:int = 0;
+        private var _hoverPoint:Point;
 
         public function SongItem()
         {
@@ -83,6 +96,7 @@ package menu
         {
             _highlight = true;
             draw();
+            showHoverMessage(true);
             this.addEventListener(MouseEvent.ROLL_OUT, e_onHoverOut);
         }
 
@@ -90,6 +104,7 @@ package menu
         {
             _highlight = false;
             draw();
+            showHoverMessage(false);
             this.removeEventListener(MouseEvent.ROLL_OUT, e_onHoverOut);
         }
 
@@ -110,6 +125,106 @@ package menu
             return isLocked;
         }
 
+        /**
+         * Displays or hides the note hover for the song item.
+         * @param enabled
+         */
+        public function showHoverMessage(enabled:Boolean):void
+        {
+            // `enabled` accounts for both `active` and `highlight`.
+            if (enabled)
+            {
+                if (highlight)
+                {
+                    // Check for Changes
+                    if (_songDetails == null)
+                        _songDetails = SQLQueries.getSongDetails((songData.engine != null ? songData.engine.id : Constant.BRAND_NAME_SHORT_LOWER()), songData.level);
+
+                    // Have a song note, show note.
+                    if (_songDetails != null && _songDetails.notes.length > 0)
+                    {
+                        if (!_hoverTimer)
+                            _hoverTimer = new Timer(500, 1);
+
+                        if (!_hoverTimer.running && (_hoverSprite == null || _hoverSprite.parent == null))
+                        {
+                            _hoverTimer.addEventListener(TimerEvent.TIMER_COMPLETE, e_hoverTimerComplete);
+                            _hoverTimer.start();
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (!highlight)
+                {
+                    if (_hoverTimer && _hoverTimer.running)
+                    {
+                        _hoverTimer.removeEventListener(TimerEvent.TIMER_COMPLETE, e_hoverTimerComplete);
+                        _hoverTimer.stop();
+                    }
+                    if (_hoverSprite && _hoverSprite.parent)
+                    {
+                        this.removeEventListener(Event.ENTER_FRAME, e_positionHoverSprite);
+                        _hoverSprite.parent.removeChild(_hoverSprite);
+                    }
+                }
+            }
+        }
+
+        private function e_hoverTimerComplete(e:Event = null):void
+        {
+            _hoverTimer.removeEventListener(TimerEvent.TIMER_COMPLETE, e_hoverTimerComplete);
+
+            if (this.parent != null)
+            {
+                if (_hoverSprite == null)
+                    _hoverSprite = new MouseTooltip("", _width - 1);
+
+                _hoverSprite.message = "<font face=\"" + Language.UNI_FONT_NAME + "\" >" + _songDetails.notes + "</font>";
+                positionHoverSprite();
+                this.parent.addChild(_hoverSprite);
+                _hoverSprite.visible = true; // Adding a child to the ScrollPane makes it invisible until a scroll update is sent.
+                this.addEventListener(Event.ENTER_FRAME, e_positionHoverSprite);
+            }
+        }
+
+        private function e_positionHoverSprite(e:Event):void
+        {
+            // Only check 12 times per second instead of 60.
+            if (++_hoverTick > 5)
+            {
+                if (_hoverSprite != null && _hoverSprite.parent != null)
+                {
+                    positionHoverSprite();
+                    _hoverTick = 0;
+                }
+                else
+                {
+                    this.removeEventListener(Event.ENTER_FRAME, e_positionHoverSprite);
+                }
+            }
+        }
+
+        /**
+         * Updates the Notes hover sprite to be above or below the item
+         * depending on the position on screen.
+         */
+        private function positionHoverSprite():void
+        {
+            if (_hoverSprite)
+            {
+                _hoverPoint = this.localToGlobal(HOVER_POINT_GLOBAL);
+
+                if (_hoverPoint.y > Main.GAME_HEIGHT / 2)
+                    _hoverSprite.y = this.y - _hoverSprite.height - 2;
+                else
+                    _hoverSprite.y = this.y + _height + 2;
+
+                _hoverSprite.x = this.x;
+            }
+        }
+
         ////////////////////////////////////////////////////////////////////////
         //- Getters / Setters
         public function setData(song:Object, rank:Object):void
@@ -120,8 +235,10 @@ package menu
 
             // Song Name
             var songname:String = song["name"];
+
             if (!song["engine"] && song["genre"] == Constant.LEGACY_GENRE)
                 songname = '<font color="#004587">[L]</font> ' + songname;
+
             _lblSongName = new Text(songname, 14);
             this.addChild(_lblSongName);
 
@@ -186,6 +303,7 @@ package menu
                 _height = 27;
             }
 
+            showHoverMessage(false);
             draw();
         }
 
@@ -235,6 +353,7 @@ package menu
         {
             _highlight = val;
             draw();
+            showHoverMessage(val);
         }
 
         public function get highlight():Boolean
@@ -246,6 +365,7 @@ package menu
         {
             _active = val;
             draw();
+            showHoverMessage(val);
         }
 
         public function get active():Boolean

--- a/src/menu/SongItem.as
+++ b/src/menu/SongItem.as
@@ -173,6 +173,11 @@ package menu
             }
         }
 
+        /**
+         * TimerEvent.TIMER_COMPLETE For the hover / active timer.
+         * Displays the song note sprite when the timer completes.
+         * @param e
+         */
         private function e_hoverTimerComplete(e:Event = null):void
         {
             _hoverTimer.removeEventListener(TimerEvent.TIMER_COMPLETE, e_hoverTimerComplete);
@@ -190,6 +195,12 @@ package menu
             }
         }
 
+        /**
+         * Event.ENTER_FRAME For note position on stage.
+         * This updates the note position every 5 frames so the message
+         * is supposedly visible when scrolled to high or low.
+         * @param e
+         */
         private function e_positionHoverSprite(e:Event):void
         {
             // Only check 12 times per second instead of 60.
@@ -226,6 +237,9 @@ package menu
             }
         }
 
+        /**
+         * Updates the note text, or displays the new note if previously empty.
+         */
         public function updateOrShow():void
         {
             if (_hoverSprite != null)
@@ -234,6 +248,9 @@ package menu
                 showHoverMessage(true);
         }
 
+        /**
+         * Update the note sprite message.
+         */
         public function update():void
         {
             if (_hoverSprite != null)

--- a/src/menu/SongItem.as
+++ b/src/menu/SongItem.as
@@ -56,6 +56,7 @@ package menu
         public var isLocked:Boolean = false;
 
         // Hover Data
+        private var _hoverEnabled:Boolean = true;
         private var _hoverTimer:Timer;
         private var _hoverSprite:MouseTooltip;
         private var _hoverTick:int = 0;
@@ -134,7 +135,7 @@ package menu
             // `enabled` accounts for both `active` and `highlight`.
             if (enabled)
             {
-                if (highlight)
+                if (highlight && _hoverEnabled)
                 {
                     // Check for Changes
                     if (_songDetails == null)
@@ -181,7 +182,7 @@ package menu
                 if (_hoverSprite == null)
                     _hoverSprite = new MouseTooltip("", _width - 1);
 
-                _hoverSprite.message = "<font face=\"" + Language.UNI_FONT_NAME + "\" >" + _songDetails.notes + "</font>";
+                update();
                 positionHoverSprite();
                 this.parent.addChild(_hoverSprite);
                 _hoverSprite.visible = true; // Adding a child to the ScrollPane makes it invisible until a scroll update is sent.
@@ -222,6 +223,14 @@ package menu
                     _hoverSprite.y = this.y + _height + 2;
 
                 _hoverSprite.x = this.x;
+            }
+        }
+
+        public function update():void
+        {
+            if (_hoverSprite != null)
+            {
+                _hoverSprite.message = "<font face=\"" + Language.UNI_FONT_NAME + "\" >" + _songDetails.notes + "</font>";
             }
         }
 
@@ -381,6 +390,16 @@ package menu
         override public function get height():Number
         {
             return _height;
+        }
+
+        public function get noteEnabled():Boolean
+        {
+            return _hoverEnabled;
+        }
+
+        public function set noteEnabled(val:Boolean):void
+        {
+            _hoverEnabled = val;
         }
     }
 }

--- a/src/menu/SongItem.as
+++ b/src/menu/SongItem.as
@@ -226,6 +226,14 @@ package menu
             }
         }
 
+        public function updateOrShow():void
+        {
+            if (_hoverSprite != null)
+                update();
+            else
+                showHoverMessage(true);
+        }
+
         public function update():void
         {
             if (_hoverSprite != null)

--- a/src/popups/PopupFilterManager.as
+++ b/src/popups/PopupFilterManager.as
@@ -389,17 +389,15 @@ package popups
                 _gvars.activeUser.saveLocal();
                 _gvars.activeUser.save();
             }
-            if (_gvars.gameMain.activePanel != null && (_gvars.gameMain.activePanel is MainMenu) && (_gvars.gameMain.activePanel as MainMenu).panel != null && (_gvars.gameMain.activePanel as MainMenu).panel is MenuSongSelection)
+
+            if (_gvars.gameMain.activePanel != null && _gvars.gameMain.activePanel is MainMenu)
             {
-                var main_menu:MainMenu = (_gvars.gameMain.activePanel as MainMenu);
-                if (main_menu != null)
+                var mmmenu:MainMenu = (_gvars.gameMain.activePanel as MainMenu);
+                if (mmmenu.panel != null && (mmmenu.panel is MenuSongSelection))
                 {
-                    var song_selection_menu:MenuSongSelection = (main_menu.panel as MenuSongSelection);
-                    if (song_selection_menu != null)
-                    {
-                        song_selection_menu.buildPlayList();
-                        song_selection_menu.buildInfoBox();
-                    }
+                    var msmenu:MenuSongSelection = (mmmenu.panel as MenuSongSelection);
+                    msmenu.buildPlayList();
+                    msmenu.buildInfoBox();
                 }
             }
         }

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -74,7 +74,7 @@ package popups
         //- Arrays
         private var keyInputs:Array = ["left", "down", "up", "right", "restart", "quit", "options"];
         private var judgeTitles:Array = ["amazing", "perfect", "good", "average", "miss", "boo"];
-        private var displayArray:Array = ["SONG_FLAG", "----", "JUDGE", "JUDGE_ANIMATIONS", "HEALTH", "SCORE", "COMBO", "PACOUNT", "SONGPROGRESS", "AMAZING", "PERFECT", "TOTAL", "SCREENCUT", "MP_MASK", "GAME_TOP_BAR", "GAME_BOTTOM_BAR"];
+        private var displayArray:Array = ["SONG_FLAG", "SONG_NOTE", "----", "JUDGE", "JUDGE_ANIMATIONS", "HEALTH", "SCORE", "COMBO", "PACOUNT", "SONGPROGRESS", "AMAZING", "PERFECT", "TOTAL", "SCREENCUT", "MP_MASK", "GAME_TOP_BAR", "GAME_BOTTOM_BAR"];
         private var noteColorComboArray:Array = [];
         private var startUpScreenSelections:Array = [];
 
@@ -1614,7 +1614,7 @@ package popups
             else if (e.target.hasOwnProperty("display"))
             {
                 _gvars.activeUser["DISPLAY_" + e.target.display] = !_gvars.activeUser["DISPLAY_" + e.target.display];
-                if (e.target.display == "SONG_FLAG")
+                if (e.target.display == "SONG_FLAG" || e.target.display == "SONG_NOTE")
                 {
                     _gvars.gameMain.activePanel.draw();
                 }

--- a/src/popups/PopupSongNotes.as
+++ b/src/popups/PopupSongNotes.as
@@ -282,7 +282,7 @@ package popups
                 if (_gvars.gameMain.activePanel != null && _gvars.gameMain.activePanel is MainMenu)
                 {
                     var mmmenu:MainMenu = (_gvars.gameMain.activePanel as MainMenu);
-                    if (mmmenu != null && (mmmenu.panel is MenuSongSelection))
+                    if (mmmenu.panel != null && (mmmenu.panel is MenuSongSelection))
                     {
                         var msmenu:MenuSongSelection = (mmmenu.panel as MenuSongSelection);
                         msmenu.updateSongItemNote(sObject.level);

--- a/src/popups/PopupSongNotes.as
+++ b/src/popups/PopupSongNotes.as
@@ -64,15 +64,7 @@ package popups
             sObject = song;
 
             songRatingValue = _gvars.playerUser.getSongRating(sObject["level"]);
-
-            SQLQueries.getSongDetails(_gvars.sql_conn, {"engine": (song.engine != null ? song.engine : Constant.BRAND_NAME_SHORT_LOWER()), "song_id": song.level}, function(result:Vector.<SQLSongDetails>):void
-            {
-                if (result != null && result.length > 0)
-                {
-                    sDetails = result[0];
-                    refreshFields();
-                }
-            });
+            sDetails = SQLQueries.getSongDetailsSafe((song.engine != null ? song.engine.id : Constant.BRAND_NAME_SHORT_LOWER()), song.level);
         }
 
         override public function stageAdd():void
@@ -295,14 +287,12 @@ package popups
 
         private function saveDetails():void
         {
-            var params:Object = {"engine": (sObject["engine"] != null ? sObject["engine"] : Constant.BRAND_NAME_SHORT_LOWER()),
-                    "song_id": sObject["level"],
-                    "offset_music": verifyFloat(optionMusicOffset.text, 0),
-                    "offset_judge": verifyFloat(optionJudgeOffset.text, 0),
-                    "set_mirror_invert": (setMirrorInvert.checked ? 1 : 0),
-                    "set_custom_offsets": (setCustomOffsets.checked ? 1 : 0),
-                    "notes": notesField.text};
-            SQLQueries.saveSongDetails(_gvars.sql_conn, params);
+            sDetails.offset_music = verifyFloat(optionMusicOffset.text, 0);
+            sDetails.offset_judge = verifyFloat(optionJudgeOffset.text, 0);
+            sDetails.set_mirror_invert = setMirrorInvert.checked;
+            sDetails.set_custom_offsets = setCustomOffsets.checked;
+            sDetails.notes = notesField.text;
+            _gvars.writeUserSongData();
         }
 
         private function verifyFloat(text:String, default_val:Number):Number

--- a/src/popups/PopupSongNotes.as
+++ b/src/popups/PopupSongNotes.as
@@ -24,7 +24,9 @@ package popups
     import flash.net.URLVariables;
     import flash.text.AntiAliasType;
     import flash.text.TextField;
+    import menu.MainMenu;
     import menu.MenuPanel;
+    import menu.MenuSongSelection;
     import sql.SQLSongDetails;
 
     public class PopupSongNotes extends MenuPanel
@@ -275,6 +277,18 @@ package popups
                 saveRatings();
                 saveDetails();
                 removePopup();
+
+                // Update the Note Hover Directly
+                if (_gvars.gameMain.activePanel != null && _gvars.gameMain.activePanel is MainMenu)
+                {
+                    var mmmenu:MainMenu = (_gvars.gameMain.activePanel as MainMenu);
+                    if (mmmenu != null && (mmmenu.panel is MenuSongSelection))
+                    {
+                        var msmenu:MenuSongSelection = (mmmenu.panel as MenuSongSelection);
+                        msmenu.updateSongItemNote(sObject.level);
+                    }
+                }
+
                 return;
             }
             //- Close

--- a/src/sql/SQLSongDetails.as
+++ b/src/sql/SQLSongDetails.as
@@ -3,23 +3,58 @@ package sql
 
     public class SQLSongDetails
     {
-        public var engine:String = "";
-        public var song_id:String = "";
         public var notes:String = "";
         public var set_mirror_invert:Boolean = false;
         public var set_custom_offsets:Boolean = false;
         public var offset_music:Number = 0;
         public var offset_judge:Number = 0;
 
-        public function SQLSongDetails(result:Object):void
+        public function SQLSongDetails(source:Object):void
         {
-            engine = result.engine;
-            song_id = result.engine;
-            notes = result.notes;
-            set_mirror_invert = result.set_mirror_invert == 1;
-            set_custom_offsets = result.set_custom_offsets == 1;
-            offset_music = result.offset_music;
-            offset_judge = result.offset_judge;
+            if (source == null)
+                return;
+
+            if (source.notes != null)
+                notes = source.notes;
+
+            if (source.set_mirror_invert != null)
+                set_mirror_invert = source.set_mirror_invert;
+
+            if (source.set_custom_offsets != null)
+                set_custom_offsets = source.set_custom_offsets;
+
+            if (source.offset_music != null)
+                offset_music = source.offset_music;
+
+            if (source.offset_judge != null)
+                offset_judge = source.offset_judge;
+        }
+
+        /**
+         * Called when `JSON.stringify` is called on this object automatically.
+         * @param k
+         * @return Object representing this class.
+         */
+        public function toJSON(k:*):Object
+        {
+            var out:Object = {};
+
+            if (notes.length > 0)
+                out["notes"] = notes;
+
+            if (offset_music != 0)
+                out["offset_music"] = offset_music;
+
+            if (offset_judge != 0)
+                out["offset_judge"] = offset_judge;
+
+            if (set_mirror_invert)
+                out["set_mirror_invert"] = set_mirror_invert;
+
+            if (set_custom_offsets)
+                out["set_custom_offsets"] = set_custom_offsets;
+
+            return out;
         }
     }
 }

--- a/src/sql/template.db
+++ b/src/sql/template.db
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e09b07a88cdddc3bc9433dc82c8a0820744aadec3307dff0cad60557d8fe1b0b
-size 16384


### PR DESCRIPTION
### Functionality:
- Replaces the old method of storing the song options from using a local SQLite DB to a more streamlined JSON text file.
- Includes a in-place converter when first loaded and backs-up the old `info.db` file.
- Adds text file read and writes.
- Removes unneeded GameOption inits for song selection context menu items.
- Cleans up the SongSelection panel redraw logic in PopupFilterManager and PopupSongNotes.

## UI:
- SongItems now displays the per song note when hovered or active. This can be disabled in the options near the song flags.
- Adds a Song Options BoxIcon into the Song Selection info box for songs.
- Replaces the song queue and highscores buttons with BoxIcons to look better.
- Cleanup the SongItem context menu and add translatable text to it.
- Changes the Star Rating for song info box to be smaller and transparent to avoid overlap with song titles.