### PR TITLE
Rewrite Noteskins to use Embedded Data instead of network

### DIFF
--- a/assets/noteskins/NoteSkin1.fla
+++ b/assets/noteskins/NoteSkin1.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d89b870490936fa5c0b8a37222b059286889641319a7a7c29bb85cdbe2688855
+size 75177

--- a/assets/noteskins/NoteSkin10.fla
+++ b/assets/noteskins/NoteSkin10.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2be8cf7e5cd2fa3c0a7c143b39942f94d184ee78c036a91c9f074f34929ebb73
+size 122895

--- a/assets/noteskins/NoteSkin2.fla
+++ b/assets/noteskins/NoteSkin2.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d88a93959bf6f98a751da92668752940824430583f70abf812908ba5023e1cf4
+size 50504

--- a/assets/noteskins/NoteSkin3.fla
+++ b/assets/noteskins/NoteSkin3.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eeeaac5f8e2244609383fb2048cb2a835d26886c0f5a0704414269571c40be9a
+size 50525

--- a/assets/noteskins/NoteSkin4.fla
+++ b/assets/noteskins/NoteSkin4.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df54b218318229fdc31c2fd9ad20c61ec5f0521e801aa34d3fdcbd8b26ad7fd6
+size 90865

--- a/assets/noteskins/NoteSkin5.fla
+++ b/assets/noteskins/NoteSkin5.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e16e5d36bdec278f8e600a3c9b2a42cc65da4c287506850076274f70c8a079c9
+size 110095

--- a/assets/noteskins/NoteSkin6.fla
+++ b/assets/noteskins/NoteSkin6.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ae4f2c5ae1fe172b65f856ad3d5dd1a9bbb81b8dcd13ba41ab6bdaddc4633fb
+size 90242

--- a/assets/noteskins/NoteSkin7.fla
+++ b/assets/noteskins/NoteSkin7.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab7cf310a113a3c7100f07e43dbf3b3d205412445f799f4233251b490c357b2a
+size 94195

--- a/assets/noteskins/NoteSkin8.fla
+++ b/assets/noteskins/NoteSkin8.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51d154f323b9b2b57ece652cf8796ff522de8955ce211f4e693aa4f81802ba06
+size 53243

--- a/assets/noteskins/NoteSkin9.fla
+++ b/assets/noteskins/NoteSkin9.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9183d2e86b18e25a556b11ff5d28ddc9bcff6ccf78c5e5faa6de37ba3afaf892
+size 44957

--- a/assets/noteskins/noteskins.fla
+++ b/assets/noteskins/noteskins.fla
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83c92996225afbb75e49aca16a0032ab5852eca35f8e104abfc0fc6b685cf078
+size 526571

--- a/src/classes/Noteskins.as
+++ b/src/classes/Noteskins.as
@@ -87,6 +87,7 @@ package classes
             else if (totalNoteskins == 0)
             {
                 _loadError = true;
+                this.dispatchEvent(new Event(GlobalVariables.LOAD_ERROR));
             }
         }
 
@@ -336,10 +337,11 @@ package classes
             imgLoader.ID = noteID;
             totalNoteskins++;
 
+            imgLoader.contentLoaderInfo.addEventListener(IOErrorEvent.IO_ERROR, e_bitmapFail);
+            imgLoader.contentLoaderInfo.addEventListener(Event.COMPLETE, e_bitmapLoad);
+
             try
             {
-                imgLoader.contentLoaderInfo.addEventListener(IOErrorEvent.IO_ERROR, e_bitmapFail);
-                imgLoader.contentLoaderInfo.addEventListener(Event.COMPLETE, e_bitmapLoad);
                 imgLoader.loadBytes(Base64.decode(mbpString), AirContext.getLoaderContext());
             }
             catch (e:Error)
@@ -357,6 +359,9 @@ package classes
         private function e_bitmapLoad(e:Event):void
         {
             var loader:DynamicLoader = e.currentTarget.loader;
+            loader.contentLoaderInfo.removeEventListener(IOErrorEvent.IO_ERROR, e_bitmapFail);
+            loader.contentLoaderInfo.removeEventListener(Event.COMPLETE, e_bitmapLoad);
+
             var noteID:String = loader.ID;
             var noteskin_struct:Object = null;
 
@@ -428,7 +433,11 @@ package classes
          */
         private function e_bitmapFail(e:Event):void
         {
-            var noteID:String = e.currentTarget.loader.ID;
+            var loader:DynamicLoader = e.currentTarget.loader;
+            loader.contentLoaderInfo.removeEventListener(IOErrorEvent.IO_ERROR, e_bitmapFail);
+            loader.contentLoaderInfo.removeEventListener(Event.COMPLETE, e_bitmapLoad);
+
+            var noteID:String = loader.ID;
 
             //- Remove From List
             totalNoteskins--;

--- a/src/game/noteskins/EmbedNoteskin1.as
+++ b/src/game/noteskins/EmbedNoteskin1.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin1 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin1.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 1;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "Default",
+                    "rotation": 90,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin10.as
+++ b/src/game/noteskins/EmbedNoteskin10.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin10 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin10.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 10;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "FFR Orbular",
+                    "rotation": 0,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin2.as
+++ b/src/game/noteskins/EmbedNoteskin2.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin2 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin2.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 2;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "Velocity",
+                    "rotation": 90,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin3.as
+++ b/src/game/noteskins/EmbedNoteskin3.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin3 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin3.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 3;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "BeatMania",
+                    "rotation": 0,
+                    "width": 88,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin4.as
+++ b/src/game/noteskins/EmbedNoteskin4.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin4 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin4.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 4;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "SM Orbular",
+                    "rotation": 0,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin5.as
+++ b/src/game/noteskins/EmbedNoteskin5.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin5 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin5.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 5;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "Metal",
+                    "rotation": 90,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin6.as
+++ b/src/game/noteskins/EmbedNoteskin6.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin6 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin6.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 6;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "Delta",
+                    "rotation": 90,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin7.as
+++ b/src/game/noteskins/EmbedNoteskin7.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin7 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin7.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 7;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "Delta (White)",
+                    "rotation": 90,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin8.as
+++ b/src/game/noteskins/EmbedNoteskin8.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin8 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin8.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 8;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "BeatMania (v2)",
+                    "rotation": 0,
+                    "width": 70,
+                    "height": 51}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskin9.as
+++ b/src/game/noteskins/EmbedNoteskin9.as
@@ -1,0 +1,31 @@
+package game.noteskins
+{
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskin9 extends EmbedNoteskinBase
+    {
+        [Embed(source = "Noteskin9.swf", mimeType = 'application/octet-stream')]
+        private static const EMBED_SWF:Class;
+
+        private static const ID:int = 9;
+
+        override public function getData():Object
+        {
+            return {"id": ID,
+                    "name": "Minestorm",
+                    "rotation": 0,
+                    "width": 64,
+                    "height": 64}
+        }
+
+        override public function getBytes():ByteArray
+        {
+            return new EMBED_SWF();
+        }
+
+        override public function getID():int
+        {
+            return ID;
+        }
+    }
+}

--- a/src/game/noteskins/EmbedNoteskinBase.as
+++ b/src/game/noteskins/EmbedNoteskinBase.as
@@ -1,0 +1,23 @@
+package game.noteskins
+{
+
+    import flash.utils.ByteArray;
+
+    public class EmbedNoteskinBase
+    {
+        public function getData():Object
+        {
+            return null;
+        }
+
+        public function getBytes():ByteArray
+        {
+            return null;
+        }
+
+        public function getID():int
+        {
+            return 1;
+        }
+    }
+}

--- a/src/game/noteskins/NoteSkin1.swf
+++ b/src/game/noteskins/NoteSkin1.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06224097b3574c466a2862b58a09c3c1e89a7f14b95a626fa5520a2e0b18d6cb
+size 66653

--- a/src/game/noteskins/NoteSkin10.swf
+++ b/src/game/noteskins/NoteSkin10.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db725724518cf8170360f7772a7d0d22895962ab4f7fc2bc1aec99cc9af697d5
+size 50723

--- a/src/game/noteskins/NoteSkin2.swf
+++ b/src/game/noteskins/NoteSkin2.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5de2c0e4adf614ec9947e8665185ad4a80ee37da5a73aeba4a4ee90e6fcef8e9
+size 16909

--- a/src/game/noteskins/NoteSkin3.swf
+++ b/src/game/noteskins/NoteSkin3.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aae9d9f78853cb122a135a818719afcb7e2ed3379c29156cee44d7a7460768f
+size 15827

--- a/src/game/noteskins/NoteSkin4.swf
+++ b/src/game/noteskins/NoteSkin4.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cde3da948233805c97a60a8c6bfe4d253ad84b076125efe841dbf1e13c582c9e
+size 32294

--- a/src/game/noteskins/NoteSkin5.swf
+++ b/src/game/noteskins/NoteSkin5.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8782acc4b8c6875114bfc274703e60e7129841ba73da621b5e7e220efaafefde
+size 46663

--- a/src/game/noteskins/NoteSkin6.swf
+++ b/src/game/noteskins/NoteSkin6.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16b04ffb2770fc57c645b96defca59ab60169de63206c867caa220e692a9524e
+size 36576

--- a/src/game/noteskins/NoteSkin7.swf
+++ b/src/game/noteskins/NoteSkin7.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e25ff19eaa4acd915c46b2780b7d33ea7fad863a8f49397cb17d08fcd45e4d45
+size 39441

--- a/src/game/noteskins/NoteSkin8.swf
+++ b/src/game/noteskins/NoteSkin8.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cd1ce584e07de4995ad694f5b5f1672a5fc9b1e6cd53d4a8ce03c63358459b6
+size 18099

--- a/src/game/noteskins/NoteSkin9.swf
+++ b/src/game/noteskins/NoteSkin9.swf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:835470cc7ed7a4dcf365713cf02acaa054d8d096326124ae56ea996c1c053bc3
+size 14000


### PR DESCRIPTION
Loading the noteskin SWF data from the server used to be needed to provided easier ways for noteskins to be added without requiring a new engine build.

Since the inclusion of Custom Noteskins, no new noteskins have been added to the network noteskins for many years and just adds to the engine load time.

This rewrite embeds all current noteskin data into the game to remove network loading, optimizes how it's loaded, and add documentation and general code cleanup to the overall class.

This also changes how noteskins are stored to remove the need for consent and slow null checks and fallbacks by filling any possible gaps in the noteskin data during the loading and verifying stage.