### PR TITLE
Check for existence of backup file before attempting to move the DB.

### DIFF
--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -126,7 +126,24 @@ package
             var sql_file:File = new File(AirContext.getAppPath(db_name + "db"));
             var json_file:File = new File(AirContext.getAppPath(db_name + "json"));
 
-            if (sql_file.exists)
+            // Use JSON first
+            if (json_file.exists)
+            {
+                var json_str:String = AirContext.readTextFile(json_file);
+                if (json_str != null)
+                {
+                    try
+                    {
+                        SQLQueries.loadFromObject(JSON.parse(json_str));
+                    }
+                    catch (e:Error)
+                    {
+
+                    }
+                }
+            }
+            // Fallback to SQL
+            else if (sql_file.exists)
             {
                 SQLQueries.exportToJSON(sql_file, function(data:Object):void
                 {
@@ -149,23 +166,6 @@ package
                         }
                     }
                 });
-            }
-
-            // Using JSON File
-            else if (json_file.exists)
-            {
-                var json_str:String = AirContext.readTextFile(json_file);
-                if (json_str != null)
-                {
-                    try
-                    {
-                        SQLQueries.loadFromObject(JSON.parse(json_str));
-                    }
-                    catch (e:Error)
-                    {
-
-                    }
-                }
             }
         }
 

--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -159,11 +159,8 @@ package
                             sql_file.moveToAsync(backupFile);
                             break;
                         }
-                        else
-                        {
-                            backupFile = new File(AirContext.getAppPath(db_name + "db.bak" + i));
-                            continue;
-                        }
+
+                        backupFile = new File(AirContext.getAppPath(db_name + "db.bak" + i));
                     }
                 });
             }

--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -132,7 +132,22 @@ package
                 {
                     SQLQueries.loadFromObject(data);
                     writeUserSongData();
-                    sql_file.moveToAsync(new File(AirContext.getAppPath(db_name + "db.bak")));
+
+                    // Create Backup File
+                    var backupFile:File = new File(AirContext.getAppPath(db_name + "db.bak"));
+                    for (var i:int = 0; i < 10; i++)
+                    {
+                        if (!backupFile.exists)
+                        {
+                            sql_file.moveToAsync(backupFile);
+                            break;
+                        }
+                        else
+                        {
+                            backupFile = new File(AirContext.getAppPath(db_name + "db.bak" + i));
+                            continue;
+                        }
+                    }
                 });
             }
 


### PR DESCRIPTION
This will check for the normal `db.bak` file before iterating though 10 more locations before giving up.

Also swap the load order so the new json format loads first before fallingf back to sql so swapping between new and old engine won't overwrite the json file each time.