### PR TITLE
Refactor clipboard code

### DIFF
--- a/src/popups/PopupCustomNoteskin.as
+++ b/src/popups/PopupCustomNoteskin.as
@@ -291,9 +291,9 @@ package popups
         {
             var success:Boolean = SystemUtil.setClipboard(noteskinsString());
             if (success)
-                GlobalVariables.instance.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
+                GlobalVariables.instance.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
             else
-                GlobalVariables.instance.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
+                GlobalVariables.instance.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
         }
 
         private function updateImage():void

--- a/src/popups/PopupCustomNoteskin.as
+++ b/src/popups/PopupCustomNoteskin.as
@@ -12,10 +12,8 @@ package popups
     import classes.Text;
     import classes.replay.Base64Decoder;
     import classes.replay.Base64Encoder;
-    import com.bit101.components.ColorChooser;
     import com.flashfla.components.ScrollPane;
     import com.flashfla.utils.ObjectUtil;
-    import com.flashfla.utils.StringUtil;
     import com.flashfla.utils.SystemUtil;
     import flash.display.Bitmap;
     import flash.display.BitmapData;
@@ -293,9 +291,9 @@ package popups
         {
             var success:Boolean = SystemUtil.setClipboard(noteskinsString());
             if (success)
-                GlobalVariables.instance.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 90, Alert.GREEN);
+                GlobalVariables.instance.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
             else
-                GlobalVariables.instance.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 90, Alert.RED);
+                GlobalVariables.instance.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
         }
 
         private function updateImage():void

--- a/src/popups/PopupFilterManager.as
+++ b/src/popups/PopupFilterManager.as
@@ -223,11 +223,11 @@ package popups
             var success:Boolean = SystemUtil.setClipboard(filterString);
             if (success)
             {
-                _gvars.gameMain.addAlert("Copied to Clipboard!", 120, Alert.GREEN);
+                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
             }
             else
             {
-                _gvars.gameMain.addAlert("Error Copying to Clipboard", 120, Alert.RED);
+                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
             }
         }
 
@@ -450,5 +450,4 @@ package popups
             }
         }
     }
-
 }

--- a/src/popups/PopupFilterManager.as
+++ b/src/popups/PopupFilterManager.as
@@ -223,11 +223,11 @@ package popups
             var success:Boolean = SystemUtil.setClipboard(filterString);
             if (success)
             {
-                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
+                _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
             }
             else
             {
-                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
+                _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
             }
         }
 

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -193,11 +193,11 @@ package popups
             var success:Boolean = SystemUtil.setClipboard(optionsString);
             if (success)
             {
-                _gvars.gameMain.addAlert("Copied to Clipboard!", 120, Alert.GREEN);
+                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
             }
             else
             {
-                _gvars.gameMain.addAlert("Error Copying to Clipboard", 120, Alert.RED);
+                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
             }
         }
 

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -193,11 +193,11 @@ package popups
             var success:Boolean = SystemUtil.setClipboard(optionsString);
             if (success)
             {
-                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
+                _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
             }
             else
             {
-                _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
+                _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
             }
         }
 

--- a/src/popups/PopupQueueManager.as
+++ b/src/popups/PopupQueueManager.as
@@ -6,7 +6,6 @@ package popups
     import classes.BoxButton;
     import classes.Language;
     import classes.Playlist;
-    import classes.replay.Replay;
     import classes.SongQueueItem;
     import classes.Text;
     import com.flashfla.components.ScrollBar;
@@ -284,17 +283,17 @@ package popups
 }
 
 import arc.mp.MultiplayerPrompt;
+import classes.Alert;
 import classes.Box;
 import classes.BoxButton;
+import classes.Language;
 import classes.Playlist;
 import classes.SongQueueItem;
 import classes.Text;
+import com.flashfla.utils.SystemUtil;
 import com.flashfla.utils.TimeUtil;
-import flash.desktop.Clipboard;
-import flash.desktop.ClipboardFormats;
 import flash.display.Sprite;
 import flash.events.MouseEvent;
-import flash.system.System;
 import menu.MainMenu;
 import menu.MenuSongSelection;
 import popups.PopupQueueManager;
@@ -302,6 +301,7 @@ import popups.PopupQueueManager;
 internal class QueueBox extends Sprite
 {
     private var _gvars:GlobalVariables = GlobalVariables.instance;
+    private var _lang:Language = Language.instance;
     private var _playlist:Playlist = Playlist.instanceCanon;
 
     //- Song Details
@@ -396,13 +396,15 @@ internal class QueueBox extends Sprite
 
     private function copyQueue():void
     {
-        try
+        var queueString:String = this.queueItem.toString();
+        var success:Boolean = SystemUtil.setClipboard(queueString);
+        if (success)
         {
-            System.setClipboard(this.queueItem.toString());
-            Clipboard.generalClipboard.setData(ClipboardFormats.TEXT_FORMAT, this.queueItem.toString());
+            _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
         }
-        catch (e:Error)
+        else
         {
+            _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
         }
     }
 

--- a/src/popups/PopupQueueManager.as
+++ b/src/popups/PopupQueueManager.as
@@ -400,11 +400,11 @@ internal class QueueBox extends Sprite
         var success:Boolean = SystemUtil.setClipboard(queueString);
         if (success)
         {
-            _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
+            _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
         }
         else
         {
-            _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_failure"), 120, Alert.RED);
+            _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
         }
     }
 

--- a/src/popups/PopupReplayHistory.as
+++ b/src/popups/PopupReplayHistory.as
@@ -703,7 +703,7 @@ internal class ReplayBox extends Sprite
         }
         else
         {
-            _gvars.gameMain.addAlert("Error Copying Replay", 120, Alert.RED);
+            _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
         }
     }
 

--- a/src/popups/PopupReplayHistory.as
+++ b/src/popups/PopupReplayHistory.as
@@ -699,7 +699,7 @@ internal class ReplayBox extends Sprite
         var success:Boolean = SystemUtil.setClipboard(replayString);
         if (success)
         {
-            _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
+            _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
         }
         else
         {

--- a/src/popups/PopupReplayHistory.as
+++ b/src/popups/PopupReplayHistory.as
@@ -1,11 +1,14 @@
 package popups
 {
+    import arc.ArcGlobals;
     import arc.mp.MultiplayerPrompt;
     import assets.GameBackgroundColor;
     import classes.Box;
     import classes.BoxButton;
+    import classes.BoxText;
     import classes.FileTracker;
     import classes.Language;
+    import classes.Playlist;
     import classes.Text;
     import classes.replay.Replay;
     import com.flashfla.components.ScrollBar;
@@ -21,9 +24,6 @@ package popups
     import flash.geom.Point;
     import flash.utils.getTimer;
     import menu.MenuPanel;
-    import classes.BoxText;
-    import arc.ArcGlobals;
-    import classes.Playlist;
 
     public class PopupReplayHistory extends MenuPanel
     {
@@ -695,11 +695,11 @@ internal class ReplayBox extends Sprite
 
     private function copyReplay():void
     {
-        var success:Boolean = SystemUtil.setClipboard(this.replay.getEncode());
-
+        var replayString:String = this.replay.getEncode();
+        var success:Boolean = SystemUtil.setClipboard(replayString);
         if (success)
         {
-            _gvars.gameMain.addAlert("Copied to Clipboard!", 120, Alert.GREEN);
+            _gvars.gameMain.addAlert(_lang.stringSimple("clipboard_success"), 120, Alert.GREEN);
         }
         else
         {


### PR DESCRIPTION
Features:
- Success and failure alerts for copying to the clipboard are displayed every time a user clicks a button that copies stuff to their clipboard.
- These alerts make use of translated strings whenever possible.
- Use `SystemUtil.setClipboard()` instead of explicit methods like `System.setClipboard()` or `Clipboard.generalClipboard.setData()` to set the clipboard, since we already have a function that does that.