### PR TITLE
Fix for playing queues from queue manager.

### DIFF
--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -1120,11 +1120,15 @@ package menu
                 tY += 23;
             }
 
+            var isQueueNotEmpty:Boolean = (options.queuePlaylist.length > 0);
+            var isQueueNotAlone:Boolean = (options.queuePlaylist.length > 1);
+
             // Actions
             var songQueuePlay:BoxButton = new BoxButton(164, 27, _lang.string("song_selection_queue_panel_play"), 12);
             songQueuePlay.x = 5;
             songQueuePlay.y = 160;
             songQueuePlay.action = "playQueue";
+            songQueuePlay.enabled = isQueueNotEmpty;
             songQueuePlay.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
             infoBox.addChild(songQueuePlay);
 
@@ -1132,6 +1136,7 @@ package menu
             songQueuePlayFromHere.x = 5;
             songQueuePlayFromHere.y = 192;
             songQueuePlayFromHere.action = "playQueueFromHere";
+            songQueuePlayFromHere.enabled = isQueueNotAlone;
             songQueuePlayFromHere.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
             infoBox.addChild(songQueuePlayFromHere);
 
@@ -1139,6 +1144,7 @@ package menu
             songQueueRandomizer.x = 5;
             songQueueRandomizer.y = 224;
             songQueueRandomizer.action = "queueRandomize";
+            songQueueRandomizer.enabled = isQueueNotAlone;
             songQueueRandomizer.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
             infoBox.addChild(songQueueRandomizer);
 
@@ -1153,6 +1159,7 @@ package menu
             songQueueSave.x = 5;
             songQueueSave.y = 288;
             songQueueSave.action = "queueSave";
+            songQueueSave.enabled = isQueueNotEmpty;
             songQueueSave.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
             infoBox.addChild(songQueueSave);
 
@@ -1160,6 +1167,7 @@ package menu
             songQueueClear.x = 89.5;
             songQueueClear.y = 288;
             songQueueClear.action = "clearQueue";
+            songQueueClear.enabled = isQueueNotEmpty;
             songQueueClear.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
             infoBox.addChild(songQueueClear);
         }

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -1397,6 +1397,7 @@ package menu
             _gvars.gameMain.addAlert(sprintf(_lang.string("song_selection_add_to_queue"), {song_name: _playlist.getSong(e.target.level).name}), 90);
             _gvars.songQueue.push(_playlist.getSong(e.target.level));
             saveQueuePlaylist();
+            buildPlayList();
             if (songList == _gvars.songQueue)
             {
                 options.infoTab = TAB_QUEUE;

--- a/src/popups/PopupQueueManager.as
+++ b/src/popups/PopupQueueManager.as
@@ -415,7 +415,7 @@ internal class QueueBox extends Sprite
 
     private function playQueue():void
     {
-        _gvars.songQueue = [];
+        var newSongQueue:Array = [];
         for each (var songid:int in queueItem.items)
         {
             var songData:Object = _playlist.playList[songid];
@@ -424,15 +424,23 @@ internal class QueueBox extends Sprite
                 var access:int = _gvars.checkSongAccess(songData);
                 if (access == GlobalVariables.SONG_ACCESS_PLAYABLE)
                 {
-                    _gvars.songQueue.push(songData);
+                    newSongQueue.push(songData);
                 }
             }
         }
 
         popup.removePopup();
-        var panel:MenuSongSelection = ((_gvars.gameMain.activePanel as MainMenu).panel as MenuSongSelection);
-        panel.buildPlayList();
-        panel.buildInfoBox();
+        MenuSongSelection.options.queuePlaylist = newSongQueue;
+        if (_gvars.gameMain.activePanel != null && _gvars.gameMain.activePanel is MainMenu)
+        {
+            var mmmenu:MainMenu = (_gvars.gameMain.activePanel as MainMenu);
+            if (mmmenu.panel != null && (mmmenu.panel is MenuSongSelection))
+            {
+                var msmenu:MenuSongSelection = (mmmenu.panel as MenuSongSelection);
+                msmenu.buildPlayList();
+                msmenu.buildInfoBox();
+            }
+        }
     }
 
     private function renameQueue():void

--- a/src/popups/PopupQueueManager.as
+++ b/src/popups/PopupQueueManager.as
@@ -430,6 +430,7 @@ internal class QueueBox extends Sprite
         }
 
         popup.removePopup();
+        _gvars.songQueue = newSongQueue;
         MenuSongSelection.options.queuePlaylist = newSongQueue;
         if (_gvars.gameMain.activePanel != null && _gvars.gameMain.activePanel is MainMenu)
         {

--- a/src/popups/PopupQueueManager.as
+++ b/src/popups/PopupQueueManager.as
@@ -430,6 +430,10 @@ internal class QueueBox extends Sprite
         }
 
         popup.removePopup();
+
+        if (newSongQueue.length <= 0)
+            return;
+
         _gvars.songQueue = newSongQueue;
         MenuSongSelection.options.queuePlaylist = newSongQueue;
         if (_gvars.gameMain.activePanel != null && _gvars.gameMain.activePanel is MainMenu)


### PR DESCRIPTION
Queue Manager was setting _gvars.songQueue directly which was changed but saved queues were changed recently yo use a different variable to display the list on the song selection screen.

Still sets _gvars.songQueue directly in the event this popup is called elsewhere in the future outside the song selection screen, as the queue to play wouldn't update till the song selection screen.

Adds a active panel safety check for the future as well.