### PR TITLE
Expand Notescale range to 10% - 150%

### DIFF
--- a/src/classes/BoxSlider.as
+++ b/src/classes/BoxSlider.as
@@ -49,7 +49,7 @@ package classes
 
         private function e_dragMove(e:MouseEvent):void
         {
-            _slideValue = (_slider.x / (_width - _slider.width)) * (_maxValue - _minValue) + _minValue;
+            _slideValue = (_slider.x / (_width - _slider.width)) * valueRange + _minValue;
 
             this.dispatchEvent(new Event(Event.CHANGE));
         }
@@ -59,19 +59,24 @@ package classes
             _slider.stopDrag();
             stage.removeEventListener(MouseEvent.MOUSE_MOVE, e_dragMove);
             stage.removeEventListener(MouseEvent.MOUSE_UP, e_stopDrag);
-            _slideValue = (_slider.x / (_width - _slider.width)) * (_maxValue - _minValue) + _minValue;
+            _slideValue = (_slider.x / (_width - _slider.width)) * valueRange + _minValue;
         }
 
         public function get slideValue():Number
         {
-            return Math.max(Math.min(_slideValue, _maxValue), _minValue) + _minValue;
+            return Math.max(Math.min(_slideValue, _maxValue), _minValue);
         }
 
         public function set slideValue(value:Number):void
         {
             _slideValue = value;
-            var moveVal:Number = Math.max(Math.min(value, _maxValue), _minValue) / (_maxValue - _minValue);
+            var moveVal:Number = (slideValue - minValue) / valueRange;
             _slider.x = (_width - _slider.width) * moveVal;
+        }
+
+        public function get valueRange():Number
+        {
+            return _maxValue - _minValue;
         }
 
         public function get minValue():Number

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -443,7 +443,8 @@ package popups
                 optionNoteScale = new BoxSlider(100, 10);
                 optionNoteScale.x = xOff;
                 optionNoteScale.y = yOff;
-                optionNoteScale.maxValue = 1;
+                optionNoteScale.minValue = 0.1;
+                optionNoteScale.maxValue = 1.5;
                 optionNoteScale.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionNoteScale);
                 yOff += 10;
@@ -1317,14 +1318,16 @@ package popups
             }
             else if (e.target == optionNoteScale)
             {
-                var snapValue:int = Math.floor(optionNoteScale.slideValue * 100 / 5) * 5;
-                _gvars.activeUser.noteScale = snapValue / 100;
-                if (isNaN(_gvars.activeUser.noteScale))
-                {
-                    _gvars.activeUser.noteScale = 1;
-                }
-                _gvars.activeUser.noteScale = Math.max(Math.min(_gvars.activeUser.noteScale, optionNoteScale.maxValue), 0.2);
-                noteScaleValueDisplay.text = Math.round(_gvars.activeUser.noteScale * 100) + "%";
+                var sliderValue:int = Math.round(Math.max(Math.min(optionNoteScale.slideValue, optionNoteScale.maxValue), optionNoteScale.minValue) * 100);
+
+                // Snap to larger value when close.
+                var snapTarget:int = 25;
+                var snapValue:int = sliderValue % snapTarget;
+                if (snapValue <= 1 || snapValue >= snapTarget - 1)
+                    sliderValue = Math.round(sliderValue / snapTarget) * snapTarget;
+
+                _gvars.activeUser.noteScale = sliderValue / 100;
+                noteScaleValueDisplay.text = sliderValue + "%";
             }
             else if (e.target == optionGameVolume)
             {

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -1319,15 +1319,11 @@ package popups
             else if (e.target == optionNoteScale)
             {
                 var sliderValue:int = Math.round(Math.max(Math.min(optionNoteScale.slideValue, optionNoteScale.maxValue), optionNoteScale.minValue) * 100);
-                if (isNaN(sliderValue))
-                {
-                    sliderValue = 100;
-                }
 
                 // Snap to larger value when close.
                 var snapTarget:int = 25;
                 var snapValue:int = sliderValue % snapTarget;
-                if (snapValue <= 1 || snapValue >= snapTarget - 1)
+                if (snapValue == 1 || snapValue == snapTarget - 1)
                     sliderValue = Math.round(sliderValue / snapTarget) * snapTarget;
 
                 _gvars.activeUser.noteScale = sliderValue / 100;

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -1319,6 +1319,10 @@ package popups
             else if (e.target == optionNoteScale)
             {
                 var sliderValue:int = Math.round(Math.max(Math.min(optionNoteScale.slideValue, optionNoteScale.maxValue), optionNoteScale.minValue) * 100);
+                if (isNaN(sliderValue))
+                {
+                    sliderValue = 100;
+                }
 
                 // Snap to larger value when close.
                 var snapTarget:int = 25;


### PR DESCRIPTION
Note Scale:
- Removes the 5% value snapping, will now snap to 25% values within 1% of the value. (99% -> 100%).
- Lower minimum scale to 10%.
- Raise maximum scale to 150%.

BoxSlider:
- Fix for when a minValue is set and a sliderValue is set positoning the slider at the wrong position.
- Add valueRange to BoxSlider.
