### PR TITLE
Multiple Fixes for Song Preview and Editor

### DIFF
--- a/src/classes/SongPreview.as
+++ b/src/classes/SongPreview.as
@@ -20,8 +20,7 @@ package classes
             if (!songData)
                 return;
 
-            if (songData)
-                this.level = songData.level;
+            this.level = songData.level;
 
             this.user = new User(false, false, 1743546);
             this.user.id = 1743546;

--- a/src/classes/SongPreview.as
+++ b/src/classes/SongPreview.as
@@ -10,39 +10,32 @@ package classes
             this.level = song_id;
         }
 
-        public function setupSongPreview():void
+        public function setupSongPreview(songData:Object = null):void
         {
             var _gvars:GlobalVariables = GlobalVariables.instance;
-            var songData:Object = Playlist.instanceCanon.playList[this.level];
+
+            if (!songData)
+                songData = Playlist.instanceCanon.playList[this.level];
 
             if (!songData)
                 return;
+
+            if (songData)
+                this.level = songData.level;
 
             this.user = new User(false, false, 1743546);
             this.user.id = 1743546;
             this.user.name = "Song Preview";
             this.user.skillLevel = _gvars.MAX_DIFFICULTY;
+            this.user.loadAvatar();
 
             this.timestamp = Math.floor((new Date()).getTime() / 1000);
-            this.score = songData["arrows"] * 50;
-            this.perfect = songData["arrows"];
-            this.good = 0;
-            this.average = 0
-            this.miss = 0;
-            this.boo = 0;
-            this.maxcombo = songData["arrows"];
             this.settings = _gvars.playerUser.settings;
 
-            this.replay = [];
-
-            var genNotes:Array = [];
-            for (var i:int = 0; i < this.maxcombo; i++)
-                genNotes.push(0);
-
-            this.generationReplayNotes = genNotes;
-            this.needsBeatboxGeneration = true;
+            this.isPreview = true;
             this.isLoaded = true;
 
+            _gvars.options.loadPreview = true;
             _gvars.options.fill();
         }
     }

--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -301,18 +301,7 @@ package classes
             setupPermissions();
 
             // Load Avatar
-            this.avatar = new Loader();
-            if (isActiveUser && this.id > 2)
-            {
-                this.avatar.contentLoaderInfo.addEventListener(Event.COMPLETE, avatarLoadComplete);
-
-                function avatarLoadComplete(e:Event):void
-                {
-                    LocalStore.setVariable("uAvatar", LoaderInfo(e.target).bytes);
-                    avatar.removeEventListener(Event.COMPLETE, avatarLoadComplete);
-                }
-            }
-            this.avatar.load(new URLRequest(Constant.USER_AVATAR_URL + "?uid=" + this.id + "&cHeight=99&cWidth=99"));
+            loadAvatar();
 
             // Setup Settings from server or local
             if (_data["settings"] != null && !this.isGuest)
@@ -361,6 +350,22 @@ package classes
             this.isMultiModerator = ArrayUtil.in_array(this.groups, [MULTI_MOD_ID, ADMIN_ID]);
             this.isMusician = ArrayUtil.in_array(this.groups, [MUSIC_PRODUCER_ID]);
             this.isSimArtist = ArrayUtil.in_array(this.groups, [SIM_AUTHOR_ID]);
+        }
+
+        public function loadAvatar():void
+        {
+            this.avatar = new Loader();
+            if (isActiveUser && this.id > 2)
+            {
+                this.avatar.contentLoaderInfo.addEventListener(Event.COMPLETE, avatarLoadComplete);
+
+                function avatarLoadComplete(e:Event):void
+                {
+                    LocalStore.setVariable("uAvatar", LoaderInfo(e.target).bytes);
+                    avatar.removeEventListener(Event.COMPLETE, avatarLoadComplete);
+                }
+            }
+            this.avatar.load(new URLRequest(Constant.USER_AVATAR_URL + "?uid=" + this.id + "&cHeight=99&cWidth=99"));
         }
 
         ///- Level Ranks

--- a/src/classes/replay/Replay.as
+++ b/src/classes/replay/Replay.as
@@ -23,6 +23,7 @@ package classes.replay
 
         public var isLoaded:Boolean = false;
         public var isEdited:Boolean = false;
+        public var isPreview:Boolean = false;
         public var generationReplayNotes:Array;
         public var needsBeatboxGeneration:Boolean = false;
 

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -9,7 +9,6 @@ package game
     import classes.GameNote;
     import classes.Language;
     import classes.Noteskins;
-    import classes.SongPreview;
     import classes.chart.LevelScriptRuntime;
     import classes.chart.Note;
     import classes.chart.NoteChart;

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -1414,10 +1414,7 @@ package game
             switchTo((options.isEditor || mpSpectate) ? Main.GAME_MENU_PANEL : GameMenu.GAME_RESULTS);
 
             // Disable Editor mode when leaving editor.
-            if (options.isEditor)
-            {
-                options.isEditor = false;
-            }
+            options.isEditor = false;
         }
 
         private function restartGame():void

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -392,6 +392,9 @@ package game
 
             _gvars.gameMain.disablePopups = false;
 
+            // Disable Editor mode when leaving editor.
+            options.isEditor = false;
+
             Mouse.show();
         }
 
@@ -1411,9 +1414,6 @@ package game
 
             // Go to results
             switchTo((options.isEditor || mpSpectate) ? Main.GAME_MENU_PANEL : GameMenu.GAME_RESULTS);
-
-            // Disable Editor mode when leaving editor.
-            options.isEditor = false;
         }
 
         private function restartGame():void

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -1295,6 +1295,7 @@ package game
                 // Set Note Counts for Preview Songs
                 if (options.replay && options.replay.isPreview)
                 {
+                    newGameResults.is_preview = true;
                     newGameResults.score = song.totalNotes * 50;
                     newGameResults.amazing = song.totalNotes;
                     newGameResults.max_combo = song.totalNotes;

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -1402,6 +1402,12 @@ package game
 
             // Go to results
             switchTo((options.isEditor || mpSpectate) ? Main.GAME_MENU_PANEL : GameMenu.GAME_RESULTS);
+
+            // Disable Editor mode when leaving editor.
+            if (options.isEditor)
+            {
+                options.isEditor = false;
+            }
         }
 
         private function restartGame():void

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -15,7 +15,6 @@ package game
     import classes.chart.NoteChart;
     import classes.chart.Song;
     import classes.replay.ReplayNote;
-    import classes.replay.ReplayPack;
     import com.flashfla.components.ProgressBar;
     import com.flashfla.net.Multiplayer;
     import com.flashfla.utils.Average;
@@ -579,10 +578,11 @@ package game
         private function initPlayerVars():void
         {
             // Force no Judge on SongPreviews
-            if (options.replay && options.replay is SongPreview)
+            if (options.replay && options.replay.isPreview)
             {
                 options.offsetJudge = 0;
                 options.offsetGlobal = 0;
+                options.isAutoplay = true;
             }
 
             reverseMod = options.modEnabled("reverse");
@@ -795,7 +795,7 @@ package game
             }
 
             // Replays
-            if (options.replay)
+            if (options.replay && !options.replay.isPreview)
             {
                 var newPress:ReplayNote = options.replay.getPress(replayPressCount);
                 if (options.replay.needsBeatboxGeneration)
@@ -1291,6 +1291,15 @@ package game
                 newGameResults.end_time = options.replay ? TimeUtil.getFormattedDate(new Date(options.replay.timestamp * 1000)) : TimeUtil.getCurrentDate();
                 newGameResults.song_progress = (gameProgress / gameLastNoteFrame);
                 newGameResults.playtime_secs = ((getTimer() - msStartTime) / 1000);
+
+                // Set Note Counts for Preview Songs
+                if (options.replay && options.replay.isPreview)
+                {
+                    newGameResults.score = song.totalNotes * 50;
+                    newGameResults.amazing = song.totalNotes;
+                    newGameResults.max_combo = song.totalNotes;
+                }
+
                 newGameResults.update(_gvars);
                 _gvars.songResults.push(newGameResults);
             }

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -505,7 +505,7 @@ package game
             }
 
             // Song Preview
-            if (_gvars.flashvars.preview_file)
+            if (_gvars.flashvars.preview_file || (result.options.replay && result.options.replay.isPreview))
             {
                 resultsDisplay.results_username.htmlText = "<B>Song Preview:</B>";
                 resultsDisplay.result_credits.htmlText = "<B>0</B>";

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -417,16 +417,16 @@ package game
 
                 // Save Replay Button
                 navSaveReplay.enabled = true;
-                if (!canSendScore(result, true, false, true, true) || _gvars.flashvars.preview_file)
+                if (!canSendScore(result, true, false, true, true) || result.is_preview)
                     navSaveReplay.enabled = false;
             }
 
             // Save Screenshot
-            if (!_gvars.flashvars.preview_file)
+            if (!result.is_preview)
                 navScreenShot.enabled = true;
 
             // Random Song Button
-            if (result.options.replay || _gvars.flashvars.preview_file || _mp.gameplayPlayingStatus())
+            if (result.options.replay || result.is_preview || _mp.gameplayPlayingStatus())
                 navRandomSong.enabled = false;
 
             // Skill rating
@@ -505,7 +505,7 @@ package game
             }
 
             // Song Preview
-            if (_gvars.flashvars.preview_file || (result.options.replay && result.options.replay.isPreview))
+            if (result.is_preview)
             {
                 resultsDisplay.results_username.htmlText = "<B>Song Preview:</B>";
                 resultsDisplay.result_credits.htmlText = "<B>0</B>";

--- a/src/game/GameScoreResult.as
+++ b/src/game/GameScoreResult.as
@@ -14,6 +14,8 @@ package game
         public var song_entry:Object;
         public var note_count:int;
 
+        public var is_preview:Boolean = false;
+
         public var legacyLastRank:Object;
 
         public var user:User;

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -849,6 +849,8 @@ package menu
          */
         private function e_setAsMenuMusicContextSelect(e:ContextMenuEvent):void
         {
+            _gvars.options = new GameOptions();
+            _gvars.options.fill();
             var songItem:SongItem = (e.contextMenuOwner as SongItem);
             var songData:Object = _playlist.getSong(songItem.level);
             if (songData.error == null)
@@ -874,12 +876,11 @@ package menu
         {
             _gvars.options = new GameOptions();
             _gvars.options.fill();
-            _gvars.options.replay = new SongPreview((e.contextMenuOwner as SongItem).level);
-            _gvars.options.loadPreview = true;
+            _gvars.options.replay = new SongPreview(0);
 
             if (!_gvars.options.replay.isLoaded)
             {
-                (_gvars.options.replay as SongPreview).setupSongPreview();
+                (_gvars.options.replay as SongPreview).setupSongPreview((e.contextMenuOwner as SongItem).songData);
             }
 
             if (_gvars.options.replay.isLoaded)

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -872,11 +872,8 @@ package menu
          */
         private function e_playChartPreviewContextSelect(e:ContextMenuEvent):void
         {
-            if (!_gvars.options)
-            {
-                _gvars.options = new GameOptions();
-                _gvars.options.fill();
-            }
+            _gvars.options = new GameOptions();
+            _gvars.options.fill();
             _gvars.options.replay = new SongPreview((e.contextMenuOwner as SongItem).level);
             _gvars.options.loadPreview = true;
 


### PR DESCRIPTION
### Changes:
- Make user avatar loading a callable function so replays and previews can load just the avatar.
- Redo song previews to use the AutoPlay bot.

### Fixes:
- Make `Song Preview` and `Menu Music` context menu items use a new GameOptions each time to prevent a crash.
- Fixes a softlock where opening the editor, then playing a song preview, would get the game stuck in both a editor and replay mode that would freeze when clicking Close.
- Fixes song previews not working for alt engines.