### PR TITLE
Fix for direct WebSocket connections.

### DIFF
--- a/src/Constant.as
+++ b/src/Constant.as
@@ -42,6 +42,8 @@ package
         public static const USER_SMALL_INFO_URL:String = ROOT_URL + "game/r3/r3-userSmallInfo.php";
         static public const ALT_SONG_SAVE_URL:String = ROOT_URL + "game/r3/r3-songSaveOther.php";
 
+        static public const WEBSOCKET_OVERLAY_URL:String = "https://github.com/flashflashrevolution/web-stream-overlay";
+
         public static const LEGACY_GENRE:int = 13;
 
         public static const MENU_MUSIC_PATH:String = "menu_music.swf";

--- a/src/be/aboutme/airserver/endpoints/socket/handlers/SocketClientHandler.as
+++ b/src/be/aboutme/airserver/endpoints/socket/handlers/SocketClientHandler.as
@@ -84,6 +84,18 @@ package be.aboutme.airserver.endpoints.socket.handlers
             //override this method in the inheriting classes
         }
 
+        public function printInvalidConnectionMessage():void
+        {
+            var response:String = "HTTP/1.0 200 OK\nContent-Type: text/html\n\nPlease use <a href=\"" + Constant.WEBSOCKET_OVERLAY_URL + "\">" + Constant.WEBSOCKET_OVERLAY_URL + "</a> to access overlay features.";
+            var responseBytes:ByteArray = new ByteArray();
+            responseBytes.writeUTFBytes(response);
+            responseBytes.position = 0;
+            socket.writeBytes(responseBytes);
+            socket.flush();
+            socketBytes.clear();
+            this.close();
+        }
+
         protected function socketCloseHandler(event:Event):void
         {
             close();

--- a/src/be/aboutme/airserver/endpoints/socket/handlers/websocket/WebSocketClientHandler.as
+++ b/src/be/aboutme/airserver/endpoints/socket/handlers/websocket/WebSocketClientHandler.as
@@ -120,6 +120,7 @@ package be.aboutme.airserver.endpoints.socket.handlers.websocket
 
                         if (!isWebsocket)
                         {
+                            printInvalidConnectionMessage();
                             return;
                         }
 
@@ -148,6 +149,11 @@ package be.aboutme.airserver.endpoints.socket.handlers.websocket
                                 close();
                                 break;
                         }
+                        return;
+                    }
+                    else
+                    {
+                        close();
                         return;
                     }
                 }

--- a/src/be/aboutme/airserver/endpoints/socket/handlers/websocket/WebSocketClientHandler.as
+++ b/src/be/aboutme/airserver/endpoints/socket/handlers/websocket/WebSocketClientHandler.as
@@ -103,6 +103,26 @@ package be.aboutme.airserver.endpoints.socket.handlers.websocket
                                 }
                             }
                         }
+
+                        //check for any fields stating websocket
+                        var isWebsocket:Boolean = (fields["Upgrade"] != null && fields["Upgrade"] == "websocket");
+                        if (!isWebsocket)
+                        {
+                            for (var field_name:String in fields)
+                            {
+                                if (field_name.toLowerCase().indexOf("websocket") >= 0)
+                                {
+                                    isWebsocket = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!isWebsocket)
+                        {
+                            return;
+                        }
+
                         //check the websocket version
                         if (fields["Sec-WebSocket-Version"] != null)
                         {

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -1085,26 +1085,26 @@ package popups
                 yOff += 30;
 
                 var autoSaveLocalCheckboxText:Text = new Text(_lang.string("air_options_save_local_replays"));
-                autoSaveLocalCheckboxText.x = xOff + 22;
+                autoSaveLocalCheckboxText.x = xOff + 20;
                 autoSaveLocalCheckboxText.y = yOff;
                 box.addChild(autoSaveLocalCheckboxText);
                 yOff += 2;
 
                 autoSaveLocalCheckbox = new BoxCheck();
-                autoSaveLocalCheckbox.x = xOff + 2;
+                autoSaveLocalCheckbox.x = xOff;
                 autoSaveLocalCheckbox.y = yOff;
                 autoSaveLocalCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                 box.addChild(autoSaveLocalCheckbox);
                 yOff += 30;
 
                 var useCacheCheckboxText:Text = new Text(_lang.string("air_options_use_cache"));
-                useCacheCheckboxText.x = xOff + 22;
+                useCacheCheckboxText.x = xOff + 20;
                 useCacheCheckboxText.y = yOff;
                 box.addChild(useCacheCheckboxText);
                 yOff += 2;
 
                 useCacheCheckbox = new BoxCheck();
-                useCacheCheckbox.x = xOff + 2;
+                useCacheCheckbox.x = xOff;
                 useCacheCheckbox.y = yOff;
                 useCacheCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                 box.addChild(useCacheCheckbox);
@@ -1113,13 +1113,13 @@ package popups
                 CONFIG::vsync
                 {
                     var useVSyncCheckboxText:Text = new Text(_lang.string("air_options_use_vsync"));
-                    useVSyncCheckboxText.x = xOff + 22;
+                    useVSyncCheckboxText.x = xOff + 20;
                     useVSyncCheckboxText.y = yOff;
                     box.addChild(useVSyncCheckboxText);
                     yOff += 2;
 
                     useVSyncCheckbox = new BoxCheck();
-                    useVSyncCheckbox.x = xOff + 2;
+                    useVSyncCheckbox.x = xOff;
                     useVSyncCheckbox.y = yOff;
                     useVSyncCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                     box.addChild(useVSyncCheckbox);
@@ -1127,13 +1127,13 @@ package popups
                 }
 
                 var useWebsocketCheckboxText:Text = new Text(_lang.string("air_options_use_websockets"));
-                useWebsocketCheckboxText.x = xOff + 22;
+                useWebsocketCheckboxText.x = xOff + 20;
                 useWebsocketCheckboxText.y = yOff;
                 box.addChild(useWebsocketCheckboxText);
                 yOff += 2;
 
                 useWebsocketCheckbox = new BoxCheck();
-                useWebsocketCheckbox.x = xOff + 2;
+                useWebsocketCheckbox.x = xOff;
                 useWebsocketCheckbox.y = yOff;
                 useWebsocketCheckbox.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
                 useWebsocketCheckbox.addEventListener(MouseEvent.MOUSE_OVER, e_websocketMouseOver, false, 0, true);

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -39,6 +39,8 @@ package popups
     import flash.geom.Point;
     import flash.media.SoundMixer;
     import flash.media.SoundTransform;
+    import flash.net.URLRequest;
+    import flash.net.navigateToURL;
     import flash.text.TextFieldAutoSize;
     import flash.ui.ContextMenu;
     import flash.ui.ContextMenuItem;
@@ -142,6 +144,7 @@ package popups
         private var autoSaveLocalCheckbox:BoxCheck;
         private var useVSyncCheckbox:BoxCheck;
         private var useWebsocketCheckbox:BoxCheck;
+        private var openWebsocketOverlay:BoxButton;
 
         public function PopupOptions(myParent:MenuPanel)
         {
@@ -1137,6 +1140,14 @@ package popups
                 box.addChild(useWebsocketCheckbox);
                 yOff += 30;
 
+                // https://github.com/flashflashrevolution/web-stream-overlay
+                openWebsocketOverlay = new BoxButton(150, 27, _lang.string("options_overlay_instructions"));
+                openWebsocketOverlay.x = xOff;
+                openWebsocketOverlay.y = yOff;
+                openWebsocketOverlay.addEventListener(MouseEvent.CLICK, clickHandler, false, 0, true);
+                box.addChild(openWebsocketOverlay);
+                yOff += 30;
+
                 ///- Col 2
                 xOff += 176;
                 yOff = BASE_Y_POSITION;
@@ -1807,6 +1818,13 @@ package popups
                         _gvars.gameMain.addAlert(_lang.string("air_options_unable_to_start_websockets"), 120, Alert.RED);
                     }
                 }
+            }
+
+            // HTTP Websockets Instructions
+            else if (e.target == openWebsocketOverlay)
+            {
+                navigateToURL(new URLRequest(Constant.WEBSOCKET_OVERLAY_URL), "_blank");
+                return;
             }
 
             // Set Settings


### PR DESCRIPTION
Accessing `localhost:<port_number>` would crash the game as it only expects websocket connections and didn't check before attempting to write a response.

Add a fields check that checks for websocket fields and bails if none found.

Also adds a instructions button under the overlay toggle to explain the feature.