### PR TITLE
Turn input boxes red for invalid settings

### DIFF
--- a/src/classes/ValidatedText.as
+++ b/src/classes/ValidatedText.as
@@ -1,0 +1,68 @@
+package classes
+{
+    import flash.text.TextFormat;
+
+    dynamic public class ValidatedText extends BoxText
+    {
+        public static const PARSE_COLOR:uint = 2;
+        public static const PARSE_FLOAT:uint = 1;
+        public static const PARSE_INT:uint = 0;
+
+        public function ValidatedText(width:int = 100, height:int = 20, textformat:TextFormat = null)
+        {
+            super(width, height, textformat);
+        }
+
+        private function renderValid():void
+        {
+            super.color = 0xFFFFFF;
+            super.borderColor = 0xFFFFFF;
+        }
+
+        private function renderInvalid():void
+        {
+            super.color = 0xFF0000;
+            super.borderColor = 0xFF0000;
+        }
+
+        /**
+         * Called to validate this class's text under a parsing mode.
+         * Modes include the following:
+         * --> PARSE_INT: Parses the text as an integer.
+         * --> PARSE_FLOAT: Parses the text as a float.
+         * --> PARSE_COLOR: Parses the text as a color (hexadecimal integer).
+         * The parsed number is then checked to see if it's not NaN and it's within the bounds supplied by the users of this function.
+         * If the text is valid:
+         * --> The BoxText is rendered to display its default colours; otherwise, it turns red.
+         * --> The parsed number is returned; otherwise, the default value is returned.
+         * @param mode Parsing mode
+         * @param default_value Value returned if validation fails
+         * @param lower_bound Lower bound of valid region
+         * @param upper_bound Upper bound of valid region
+         * @return Number The parsed number if validation succeeds; the default value if validation fails
+         */
+        public function validate(mode:uint, default_value:Number, lower_bound:Number = NaN, upper_bound:Number = NaN):Number
+        {
+            var parse_color:Boolean = Boolean(mode & PARSE_COLOR);
+            var parse_float:Boolean = !parse_color && Boolean(mode & PARSE_FLOAT);
+            var radix:int = parse_color ? 16 : 0;
+
+            var testString:String = this.text;
+            if (parse_color)
+                testString = "0x" + testString.replace("#", "");
+
+            var to_test:Number = (parse_float) ? parseFloat(testString) : parseInt(testString, radix);
+            var valid:Boolean = !(isNaN(to_test) || (!isNaN(lower_bound) && to_test < lower_bound) || (!isNaN(upper_bound) && to_test > upper_bound));
+            if (valid)
+            {
+                renderValid();
+                return to_test;
+            }
+            else
+            {
+                renderInvalid();
+                return default_value;
+            }
+        }
+    }
+}

--- a/src/classes/ValidatedText.as
+++ b/src/classes/ValidatedText.as
@@ -15,6 +15,8 @@ package classes
         public static const R_COLOR:uint = 4;
         public static const R_ALL:uint = 5;
 
+        private var m_validator:RegExp;
+
         /**
          * The ValidatedText constructor.
          * restrict_mode determines what characters could be entered into the textfield:
@@ -36,18 +38,22 @@ package classes
             {
                 case R_FLOAT_P:
                     this.restrict = "0-9.";
+                    m_validator = /^\d*\.?\d*$/;
                     break;
                 case R_FLOAT:
                     this.restrict = "\\-0-9.";
+                    m_validator = /^-?\d*\.?\d*$/;
                     break;
                 case R_INT_P:
                     this.restrict = "0-9";
                     break;
                 case R_INT:
                     this.restrict = "\\-0-9";
+                    m_validator = /^-?\d+$/;
                     break;
                 case R_COLOR:
                     this.restrict = "#0-9a-f";
+                    m_validator = /^#[0-9a-f]{6}$/;
                     break;
             }
         }
@@ -87,11 +93,12 @@ package classes
             var radix:int = parse_color ? 16 : 0;
 
             var testString:String = this.text;
+            var regex_passed:Boolean = (m_validator != null) ? m_validator.test(testString) : true;
             if (parse_color)
                 testString = "0x" + testString.replace("#", "");
 
             var to_test:Number = (parse_float) ? parseFloat(testString) : parseInt(testString, radix);
-            var valid:Boolean = !(isNaN(to_test) || (!isNaN(lower_bound) && to_test < lower_bound) || (!isNaN(upper_bound) && to_test > upper_bound));
+            var valid:Boolean = !(!regex_passed || isNaN(to_test) || (!isNaN(lower_bound) && to_test < lower_bound) || (!isNaN(upper_bound) && to_test > upper_bound));
             if (valid)
             {
                 renderValid();

--- a/src/classes/ValidatedText.as
+++ b/src/classes/ValidatedText.as
@@ -76,7 +76,8 @@ package classes
          * --> PARSE_INT: Parses the text as an integer.
          * --> PARSE_FLOAT: Parses the text as a float.
          * --> PARSE_COLOR: Parses the text as a color (hexadecimal integer).
-         * The parsed number is then checked to see if it's not NaN and it's within the bounds supplied by the users of this function.
+         * First, the text is checked if it passes a regex test.
+         * Then, the parsed number is checked to see if it's not NaN and it's within the bounds supplied by the users of this function.
          * If the text is valid:
          * --> The BoxText is rendered to display its default colours; otherwise, it turns red.
          * --> The parsed number is returned; otherwise, the default value is returned.

--- a/src/classes/ValidatedText.as
+++ b/src/classes/ValidatedText.as
@@ -8,9 +8,48 @@ package classes
         public static const PARSE_FLOAT:uint = 1;
         public static const PARSE_INT:uint = 0;
 
-        public function ValidatedText(width:int = 100, height:int = 20, textformat:TextFormat = null)
+        public static const R_FLOAT_P:uint = 0;
+        public static const R_FLOAT:uint = 1;
+        public static const R_INT_P:uint = 2;
+        public static const R_INT:uint = 3;
+        public static const R_COLOR:uint = 4;
+        public static const R_ALL:uint = 5;
+
+        /**
+         * The ValidatedText constructor.
+         * restrict_mode determines what characters could be entered into the textfield:
+         * --> R_FLOAT_P: A positive decimal.
+         * --> R_FLOAT: A decimal.
+         * --> R_INT_P: A positive integer.
+         * --> R_INT: An integer.
+         * --> R_COLOR: A hex string, including the pound ('#') sign.
+         * --> R_ALL: No restriction.
+         * @param width Width of the textfield
+         * @param height Height of the textfield
+         * @param restrict_mode Which restricted character set to be used
+         * @param textformat TextFormat of the textfield
+         */
+        public function ValidatedText(width:int, height:int, restrict_mode:uint, textformat:TextFormat = null)
         {
             super(width, height, textformat);
+            switch (restrict_mode)
+            {
+                case R_FLOAT_P:
+                    this.restrict = "0-9.";
+                    break;
+                case R_FLOAT:
+                    this.restrict = "\\-0-9.";
+                    break;
+                case R_INT_P:
+                    this.restrict = "0-9";
+                    break;
+                case R_INT:
+                    this.restrict = "\\-0-9";
+                    break;
+                case R_COLOR:
+                    this.restrict = "#0-9a-f";
+                    break;
+            }
         }
 
         private function renderValid():void
@@ -26,7 +65,7 @@ package classes
         }
 
         /**
-         * Called to validate this class's text under a parsing mode.
+         * Called to validate the text of a ValidatedText in different modes.
          * Modes include the following:
          * --> PARSE_INT: Parses the text as an integer.
          * --> PARSE_FLOAT: Parses the text as a float.

--- a/src/classes/ValidatedText.as
+++ b/src/classes/ValidatedText.as
@@ -4,9 +4,9 @@ package classes
 
     dynamic public class ValidatedText extends BoxText
     {
-        public static const PARSE_COLOR:uint = 2;
-        public static const PARSE_FLOAT:uint = 1;
-        public static const PARSE_INT:uint = 0;
+        private static const PARSE_COLOR:uint = 2;
+        private static const PARSE_FLOAT:uint = 1;
+        private static const PARSE_INT:uint = 0;
 
         public static const R_FLOAT_P:uint = 0;
         public static const R_FLOAT:uint = 1;
@@ -15,6 +15,7 @@ package classes
         public static const R_COLOR:uint = 4;
         public static const R_ALL:uint = 5;
 
+        private var m_parseMode:uint = PARSE_INT;
         private var m_validator:RegExp;
 
         /**
@@ -38,21 +39,26 @@ package classes
             {
                 case R_FLOAT_P:
                     this.restrict = "0-9.";
+                    m_parseMode = PARSE_FLOAT;
                     m_validator = /^\d*\.?\d*$/;
                     break;
                 case R_FLOAT:
                     this.restrict = "\\-0-9.";
+                    m_parseMode = PARSE_FLOAT;
                     m_validator = /^-?\d*\.?\d*$/;
                     break;
                 case R_INT_P:
                     this.restrict = "0-9";
+                    m_parseMode = PARSE_INT;
                     break;
                 case R_INT:
                     this.restrict = "\\-0-9";
+                    m_parseMode = PARSE_INT;
                     m_validator = /^-?\d+$/;
                     break;
                 case R_COLOR:
                     this.restrict = "#0-9a-f";
+                    m_parseMode = PARSE_COLOR;
                     m_validator = /^#[0-9a-f]{6}$/;
                     break;
             }
@@ -71,26 +77,21 @@ package classes
         }
 
         /**
-         * Called to validate the text of a ValidatedText in different modes.
-         * Modes include the following:
-         * --> PARSE_INT: Parses the text as an integer.
-         * --> PARSE_FLOAT: Parses the text as a float.
-         * --> PARSE_COLOR: Parses the text as a color (hexadecimal integer).
+         * Called to validate the text of a ValidatedText according to the restricted character set.
          * First, the text is checked if it passes a regex test.
          * Then, the parsed number is checked to see if it's not NaN and it's within the bounds supplied by the users of this function.
          * If the text is valid:
          * --> The BoxText is rendered to display its default colours; otherwise, it turns red.
          * --> The parsed number is returned; otherwise, the default value is returned.
-         * @param mode Parsing mode
          * @param default_value Value returned if validation fails
          * @param lower_bound Lower bound of valid region
          * @param upper_bound Upper bound of valid region
          * @return Number The parsed number if validation succeeds; the default value if validation fails
          */
-        public function validate(mode:uint, default_value:Number, lower_bound:Number = NaN, upper_bound:Number = NaN):Number
+        public function validate(default_value:Number, lower_bound:Number = NaN, upper_bound:Number = NaN):Number
         {
-            var parse_color:Boolean = Boolean(mode & PARSE_COLOR);
-            var parse_float:Boolean = !parse_color && Boolean(mode & PARSE_FLOAT);
+            var parse_color:Boolean = (m_parseMode == PARSE_COLOR);
+            var parse_float:Boolean = (m_parseMode == PARSE_FLOAT);
             var radix:int = parse_color ? 16 : 0;
 
             var testString:String = this.text;

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -1603,12 +1603,14 @@ package popups
             else if (e.target.hasOwnProperty("judge_color_reset_id"))
             {
                 _gvars.activeUser.judgeColours[e.target.judge_color_reset_id] = DEFAULT_OPTIONS.judgeColours[e.target.judge_color_reset_id];
+                renderOptions();
             }
 
             // Combo Color Reset
             else if (e.target.hasOwnProperty("combo_color_reset_id"))
             {
                 _gvars.activeUser.comboColours[e.target.combo_color_reset_id] = DEFAULT_OPTIONS.comboColours[e.target.combo_color_reset_id];
+                renderOptions();
             }
 
             // Combo Color Enable/Disable
@@ -1626,6 +1628,7 @@ package popups
                     _gvars.activeUser.gameColours[2] = ColorUtil.darkenColor(DEFAULT_OPTIONS.gameColours[gid], 0.27);
                 if (gid == 1)
                     _gvars.activeUser.gameColours[3] = ColorUtil.brightenColor(DEFAULT_OPTIONS.gameColours[gid], 0.08);
+                renderOptions();
             }
             //- Editor
             else if (e.target.hasOwnProperty("editor_multiplayer"))

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -16,6 +16,7 @@ package popups
     import classes.Playlist;
     import classes.Text;
     import classes.User;
+    import classes.ValidatedText;
     import classes.chart.Song;
     import classes.chart.parse.ChartFFRLegacy;
     import com.bit101.components.ComboBox;
@@ -93,18 +94,18 @@ package popups
         private var hover_message:MouseTooltip;
 
         //- Options
-        private var optionGameSpeed:BoxText;
-        private var optionOffset:BoxText;
-        private var optionJudgeOffset:BoxText;
-        private var gameJudgeOffset:Text
+        private var optionGameSpeed:ValidatedText;
+        private var optionOffset:ValidatedText;
+        private var optionJudgeOffset:ValidatedText;
+        private var gameJudgeOffset:Text;
         private var autoJudgeOffsetCheck:BoxCheck;
         private var gameAutoJudgeOffset:Text;
-        private var optionReceptorSpacing:BoxText;
+        private var optionReceptorSpacing:ValidatedText;
         private var optionNoteScale:BoxSlider;
         private var optionGameVolume:BoxSlider;
         private var gameVolumeValueDisplay:Text;
-        private var optionFPS:BoxText;
-        private var optionRate:BoxText;
+        private var optionFPS:ValidatedText;
+        private var optionRate:ValidatedText;
         private var forceJudgeCheck:BoxCheck;
         private var gameForceJudgeMode:Text;
         private var optionScrollDirections:Vector.<BoxCheck>;
@@ -129,7 +130,7 @@ package popups
 
         private var isolationText:BoxText;
         private var isolationTotalText:BoxText;
-        private var optionMPSize:BoxText;
+        private var optionMPSize:ValidatedText;
         private var timestampCheck:BoxCheck;
         private var startUpScreenCombo:ComboBox;
         private var optionGameLanguages:Array;
@@ -365,7 +366,7 @@ package popups
                 box.addChild(gameSpeed);
                 yOff += 20;
 
-                optionGameSpeed = new BoxText(100, 20);
+                optionGameSpeed = new ValidatedText(100, 20);
                 optionGameSpeed.x = xOff;
                 optionGameSpeed.y = yOff;
                 optionGameSpeed.restrict = "0-9.";
@@ -380,7 +381,7 @@ package popups
                 box.addChild(gameOffset);
                 yOff += 20;
 
-                optionOffset = new BoxText(100, 20);
+                optionOffset = new ValidatedText(100, 20);
                 optionOffset.x = xOff;
                 optionOffset.y = yOff;
                 optionOffset.restrict = "-0-9";
@@ -395,7 +396,7 @@ package popups
                 box.addChild(gameJudgeOffset);
                 yOff += 20;
 
-                optionJudgeOffset = new BoxText(100, 20);
+                optionJudgeOffset = new ValidatedText(100, 20);
                 optionJudgeOffset.x = xOff;
                 optionJudgeOffset.y = yOff;
                 optionJudgeOffset.restrict = "-0-9";
@@ -425,7 +426,7 @@ package popups
                 box.addChild(gameReceptorSpacing);
                 yOff += 20;
 
-                optionReceptorSpacing = new BoxText(100, 20);
+                optionReceptorSpacing = new ValidatedText(100, 20);
                 optionReceptorSpacing.x = xOff;
                 optionReceptorSpacing.y = yOff;
                 optionReceptorSpacing.restrict = "-0-9";
@@ -461,7 +462,7 @@ package popups
                 box.addChild(gameFPS);
                 yOff += 20;
 
-                optionFPS = new BoxText(100, 20);
+                optionFPS = new ValidatedText(100, 20);
                 optionFPS.x = xOff;
                 optionFPS.y = yOff;
                 optionFPS.restrict = "0-9";
@@ -476,7 +477,7 @@ package popups
                 box.addChild(gameRate);
                 yOff += 20;
 
-                optionRate = new BoxText(100, 20);
+                optionRate = new ValidatedText(100, 20);
                 optionRate.x = xOff;
                 optionRate.y = yOff;
                 optionRate.restrict = ".0-9";
@@ -621,7 +622,7 @@ package popups
                     optionAutofailText.y = yOff - 1;
                     box.addChild(optionAutofailText);
 
-                    var optionAutofailInput:BoxText = new BoxText(70, 20);
+                    var optionAutofailInput:ValidatedText = new ValidatedText(70, 20);
                     optionAutofailInput.x = xOff;
                     optionAutofailInput.y = yOff;
                     optionAutofailInput.autofail = judgeTitles[i];
@@ -638,7 +639,7 @@ package popups
                 optionAutofailText.y = yOff - 1;
                 box.addChild(optionAutofailText);
 
-                optionAutofailInput = new BoxText(70, 20);
+                optionAutofailInput = new ValidatedText(70, 20);
                 optionAutofailInput.x = xOff;
                 optionAutofailInput.y = yOff;
                 optionAutofailInput.autofail = "rawGoods";
@@ -859,7 +860,7 @@ package popups
                     gameJudgeColor.align = Text.RIGHT;
                     box.addChild(gameJudgeColor);
 
-                    var optionJudgeColor:BoxText = new BoxText(70, 20);
+                    var optionJudgeColor:ValidatedText = new ValidatedText(70, 20);
                     optionJudgeColor.x = xOff + 75;
                     optionJudgeColor.y = yOff;
                     optionJudgeColor.judge_color_id = i;
@@ -909,7 +910,7 @@ package popups
                     gameGameColor.align = Text.RIGHT;
                     box.addChild(gameGameColor);
 
-                    var optionGameColor:BoxText = new BoxText(70, 20);
+                    var optionGameColor:ValidatedText = new ValidatedText(70, 20);
                     optionGameColor.x = xOff + 75;
                     optionGameColor.y = yOff;
                     optionGameColor.game_color_id = i;
@@ -959,7 +960,7 @@ package popups
                     gameComboColor.align = Text.RIGHT;
                     box.addChild(gameComboColor);
 
-                    var optionComboColor:BoxText = new BoxText(70, 20);
+                    var optionComboColor:ValidatedText = new ValidatedText(70, 20);
                     optionComboColor.x = xOff + 75;
                     optionComboColor.y = yOff;
                     optionComboColor.combo_color_id = i;
@@ -1148,7 +1149,7 @@ package popups
                 box.addChild(gameMPTextSize);
                 yOff += 20;
 
-                optionMPSize = new BoxText(100, 20);
+                optionMPSize = new ValidatedText(100, 20);
                 optionMPSize.x = xOff;
                 optionMPSize.y = yOff;
                 optionMPSize.restrict = "0-9";
@@ -1285,35 +1286,19 @@ package popups
         {
             if (e.target == optionGameSpeed)
             {
-                _gvars.activeUser.gameSpeed = parseFloat(optionGameSpeed.text);
-                if (isNaN(_gvars.activeUser.gameSpeed) || _gvars.activeUser.gameSpeed <= 0.1)
-                {
-                    _gvars.activeUser.gameSpeed = 1;
-                }
+                _gvars.activeUser.gameSpeed = optionGameSpeed.validate(ValidatedText.PARSE_FLOAT, 1, 0.1);
             }
             else if (e.target == optionOffset)
             {
-                _gvars.activeUser.GLOBAL_OFFSET = parseFloat(optionOffset.text);
-                if (isNaN(_gvars.activeUser.GLOBAL_OFFSET))
-                {
-                    _gvars.activeUser.GLOBAL_OFFSET = 0;
-                }
+                _gvars.activeUser.GLOBAL_OFFSET = optionOffset.validate(ValidatedText.PARSE_FLOAT, 0);
             }
             else if (e.target == optionJudgeOffset)
             {
-                _gvars.activeUser.JUDGE_OFFSET = parseFloat(optionJudgeOffset.text);
-                if (isNaN(_gvars.activeUser.JUDGE_OFFSET))
-                {
-                    _gvars.activeUser.JUDGE_OFFSET = 0;
-                }
+                _gvars.activeUser.JUDGE_OFFSET = optionJudgeOffset.validate(ValidatedText.PARSE_FLOAT, 0);
             }
             else if (e.target == optionReceptorSpacing)
             {
-                _gvars.activeUser.receptorGap = parseInt(optionReceptorSpacing.text);
-                if (isNaN(_gvars.activeUser.receptorGap))
-                {
-                    _gvars.activeUser.receptorGap = 80;
-                }
+                _gvars.activeUser.receptorGap = optionReceptorSpacing.validate(ValidatedText.PARSE_INT, 80);
             }
             else if (e.target == optionNoteScale)
             {
@@ -1338,18 +1323,14 @@ package popups
             }
             else if (e.target == optionFPS)
             {
-                _gvars.activeUser.frameRate = parseInt(optionFPS.text);
-                if (isNaN(_gvars.activeUser.frameRate))
-                    _gvars.activeUser.frameRate = 60;
+                _gvars.activeUser.frameRate = optionFPS.validate(ValidatedText.PARSE_INT, 60);
                 _gvars.activeUser.frameRate = Math.max(Math.min(_gvars.activeUser.frameRate, 250), 10);
                 forceJudgeCheck.visible = gameForceJudgeMode.visible = (_gvars.activeUser.frameRate <= 30);
                 _gvars.removeSongFiles();
             }
             else if (e.target == optionRate)
             {
-                _gvars.activeUser.songRate = parseFloat(optionRate.text);
-                if (isNaN(_gvars.activeUser.songRate) || _gvars.activeUser.songRate < 0.1)
-                    _gvars.activeUser.songRate = 1;
+                _gvars.activeUser.songRate = optionRate.validate(ValidatedText.PARSE_FLOAT, 1, 0.1);
                 _gvars.removeSongFiles();
             }
             else if (e.target == isolationText)
@@ -1364,44 +1345,30 @@ package popups
             }
             else if (e.target == optionMPSize)
             {
-                _avars.configMPSize = parseInt(optionMPSize.text);
-                if (isNaN(_avars.configMPSize))
-                    _avars.configMPSize = 10;
-                Style.fontSize = _avars.configMPSize;
+                Style.fontSize = _avars.configMPSize = optionMPSize.validate(ValidatedText.PARSE_INT, 10);
                 _avars.mpSave();
             }
             else if (e.target.hasOwnProperty("autofail"))
             {
-                var t:BoxText = e.target as BoxText;
-                var autofail:String = StringUtil.upperCase(t.autofail);
-                _gvars.activeUser["autofail" + autofail] = parseInt(t.text);
-                if (isNaN(_gvars.activeUser["autofail" + autofail]) || _gvars.activeUser["autofail" + autofail] < 0)
-                    _gvars.activeUser["autofail" + autofail] = 0;
+                var autofail:String = StringUtil.upperCase(e.target.autofail);
+                _gvars.activeUser["autofail" + autofail] = e.target.validate(ValidatedText.PARSE_INT, 0, 0);
             }
             else if (e.target.hasOwnProperty("judge_color_id"))
             {
                 var jid:int = e.target.judge_color_id;
-                var newColorJ:int = parseInt("0x" + e.target.text.replace("#", ""), 16);
-                if (isNaN(newColorJ) || newColorJ < 0)
-                    newColorJ = 0;
-                _gvars.activeUser.judgeColours[jid] = newColorJ;
+                _gvars.activeUser.judgeColours[jid] = e.target.validate(ValidatedText.PARSE_COLOR, 0, 0);
                 optionJudgeColors[jid]["display"].color = _gvars.activeUser.judgeColours[jid];
             }
             else if (e.target.hasOwnProperty("combo_color_id"))
             {
                 var cid:int = e.target.combo_color_id;
-                var newColorC:int = parseInt("0x" + e.target.text.replace("#", ""), 16);
-                if (isNaN(newColorC) || newColorC < 0)
-                    newColorC = 0;
-                _gvars.activeUser.comboColours[cid] = newColorC;
+                _gvars.activeUser.comboColours[cid] = e.target.validate(ValidatedText.PARSE_COLOR, 0, 0);
                 optionComboColors[cid]["display"].color = _gvars.activeUser.comboColours[cid];
             }
             else if (e.target.hasOwnProperty("game_color_id"))
             {
                 var gid:int = e.target.game_color_id;
-                var newColorG:int = parseInt("0x" + e.target.text.replace("#", ""), 16);
-                if (isNaN(newColorG) || newColorG < 0)
-                    newColorG = 0;
+                var newColorG:Number = e.target.validate(ValidatedText.PARSE_COLOR, 0, 0);
                 _gvars.activeUser.gameColours[gid] = newColorG;
 
                 if (gid == 0)

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -1272,19 +1272,19 @@ package popups
         {
             if (e.target == optionGameSpeed)
             {
-                _gvars.activeUser.gameSpeed = optionGameSpeed.validate(ValidatedText.PARSE_FLOAT, 1, 0.1);
+                _gvars.activeUser.gameSpeed = optionGameSpeed.validate(1, 0.1);
             }
             else if (e.target == optionOffset)
             {
-                _gvars.activeUser.GLOBAL_OFFSET = optionOffset.validate(ValidatedText.PARSE_FLOAT, 0);
+                _gvars.activeUser.GLOBAL_OFFSET = optionOffset.validate(0);
             }
             else if (e.target == optionJudgeOffset)
             {
-                _gvars.activeUser.JUDGE_OFFSET = optionJudgeOffset.validate(ValidatedText.PARSE_FLOAT, 0);
+                _gvars.activeUser.JUDGE_OFFSET = optionJudgeOffset.validate(0);
             }
             else if (e.target == optionReceptorSpacing)
             {
-                _gvars.activeUser.receptorGap = optionReceptorSpacing.validate(ValidatedText.PARSE_INT, 80);
+                _gvars.activeUser.receptorGap = optionReceptorSpacing.validate(80);
             }
             else if (e.target == optionNoteScale)
             {
@@ -1309,52 +1309,52 @@ package popups
             }
             else if (e.target == optionFPS)
             {
-                _gvars.activeUser.frameRate = optionFPS.validate(ValidatedText.PARSE_INT, 60);
+                _gvars.activeUser.frameRate = optionFPS.validate(60);
                 _gvars.activeUser.frameRate = Math.max(Math.min(_gvars.activeUser.frameRate, 250), 10);
                 forceJudgeCheck.visible = gameForceJudgeMode.visible = (_gvars.activeUser.frameRate <= 30);
                 _gvars.removeSongFiles();
             }
             else if (e.target == optionRate)
             {
-                _gvars.activeUser.songRate = optionRate.validate(ValidatedText.PARSE_FLOAT, 1, 0.1);
+                _gvars.activeUser.songRate = optionRate.validate(1, 0.1);
                 _gvars.removeSongFiles();
             }
             else if (e.target == isolationText)
             {
-                _avars.configIsolationStart = isolationText.validate(ValidatedText.PARSE_INT, 1, 1) - 1;
+                _avars.configIsolationStart = isolationText.validate(1, 1) - 1;
                 _avars.configIsolation = _avars.configIsolationStart > 0 || _avars.configIsolationLength > 0;
             }
             else if (e.target == isolationTotalText)
             {
-                _avars.configIsolationLength = isolationTotalText.validate(ValidatedText.PARSE_INT, 0);
+                _avars.configIsolationLength = isolationTotalText.validate(0);
                 _avars.configIsolation = _avars.configIsolationStart > 0 || _avars.configIsolationLength > 0;
             }
             else if (e.target == optionMPSize)
             {
-                Style.fontSize = _avars.configMPSize = optionMPSize.validate(ValidatedText.PARSE_INT, 10);
+                Style.fontSize = _avars.configMPSize = optionMPSize.validate(10);
                 _avars.mpSave();
             }
             else if (e.target.hasOwnProperty("autofail"))
             {
                 var autofail:String = StringUtil.upperCase(e.target.autofail);
-                _gvars.activeUser["autofail" + autofail] = e.target.validate(ValidatedText.PARSE_INT, 0, 0);
+                _gvars.activeUser["autofail" + autofail] = e.target.validate(0, 0);
             }
             else if (e.target.hasOwnProperty("judge_color_id"))
             {
                 var jid:int = e.target.judge_color_id;
-                _gvars.activeUser.judgeColours[jid] = e.target.validate(ValidatedText.PARSE_COLOR, 0, 0);
+                _gvars.activeUser.judgeColours[jid] = e.target.validate(0, 0);
                 optionJudgeColors[jid]["display"].color = _gvars.activeUser.judgeColours[jid];
             }
             else if (e.target.hasOwnProperty("combo_color_id"))
             {
                 var cid:int = e.target.combo_color_id;
-                _gvars.activeUser.comboColours[cid] = e.target.validate(ValidatedText.PARSE_COLOR, 0, 0);
+                _gvars.activeUser.comboColours[cid] = e.target.validate(0, 0);
                 optionComboColors[cid]["display"].color = _gvars.activeUser.comboColours[cid];
             }
             else if (e.target.hasOwnProperty("game_color_id"))
             {
                 var gid:int = e.target.game_color_id;
-                var newColorG:Number = e.target.validate(ValidatedText.PARSE_COLOR, 0, 0);
+                var newColorG:Number = e.target.validate(0, 0);
                 _gvars.activeUser.gameColours[gid] = newColorG;
 
                 if (gid == 0)

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -128,8 +128,8 @@ package popups
         private var optionGameColors:Array;
         private var optionNoteColors:Array;
 
-        private var isolationText:BoxText;
-        private var isolationTotalText:BoxText;
+        private var isolationText:ValidatedText;
+        private var isolationTotalText:ValidatedText;
         private var optionMPSize:ValidatedText;
         private var timestampCheck:BoxCheck;
         private var startUpScreenCombo:ComboBox;
@@ -366,10 +366,9 @@ package popups
                 box.addChild(gameSpeed);
                 yOff += 20;
 
-                optionGameSpeed = new ValidatedText(100, 20);
+                optionGameSpeed = new ValidatedText(100, 20, ValidatedText.R_FLOAT_P);
                 optionGameSpeed.x = xOff;
                 optionGameSpeed.y = yOff;
-                optionGameSpeed.restrict = "0-9.";
                 optionGameSpeed.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionGameSpeed);
                 yOff += 30;
@@ -381,10 +380,9 @@ package popups
                 box.addChild(gameOffset);
                 yOff += 20;
 
-                optionOffset = new ValidatedText(100, 20);
+                optionOffset = new ValidatedText(100, 20, ValidatedText.R_FLOAT);
                 optionOffset.x = xOff;
                 optionOffset.y = yOff;
-                optionOffset.restrict = "-0-9";
                 optionOffset.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionOffset);
                 yOff += 30;
@@ -396,10 +394,9 @@ package popups
                 box.addChild(gameJudgeOffset);
                 yOff += 20;
 
-                optionJudgeOffset = new ValidatedText(100, 20);
+                optionJudgeOffset = new ValidatedText(100, 20, ValidatedText.R_FLOAT);
                 optionJudgeOffset.x = xOff;
                 optionJudgeOffset.y = yOff;
-                optionJudgeOffset.restrict = "-0-9";
                 optionJudgeOffset.addEventListener(Event.CHANGE, changeHandler);
                 optionJudgeOffset.contextMenu = arcJudgeMenu();
                 box.addChild(optionJudgeOffset);
@@ -426,10 +423,9 @@ package popups
                 box.addChild(gameReceptorSpacing);
                 yOff += 20;
 
-                optionReceptorSpacing = new ValidatedText(100, 20);
+                optionReceptorSpacing = new ValidatedText(100, 20, ValidatedText.R_INT);
                 optionReceptorSpacing.x = xOff;
                 optionReceptorSpacing.y = yOff;
-                optionReceptorSpacing.restrict = "-0-9";
                 optionReceptorSpacing.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionReceptorSpacing);
                 yOff += 30;
@@ -462,10 +458,9 @@ package popups
                 box.addChild(gameFPS);
                 yOff += 20;
 
-                optionFPS = new ValidatedText(100, 20);
+                optionFPS = new ValidatedText(100, 20, ValidatedText.R_INT_P);
                 optionFPS.x = xOff;
                 optionFPS.y = yOff;
-                optionFPS.restrict = "0-9";
                 optionFPS.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionFPS);
                 yOff += 30;
@@ -477,10 +472,9 @@ package popups
                 box.addChild(gameRate);
                 yOff += 20;
 
-                optionRate = new ValidatedText(100, 20);
+                optionRate = new ValidatedText(100, 20, ValidatedText.R_FLOAT_P);
                 optionRate.x = xOff;
                 optionRate.y = yOff;
-                optionRate.restrict = ".0-9";
                 optionRate.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionRate);
                 yOff += 40;
@@ -622,11 +616,10 @@ package popups
                     optionAutofailText.y = yOff - 1;
                     box.addChild(optionAutofailText);
 
-                    var optionAutofailInput:ValidatedText = new ValidatedText(70, 20);
+                    var optionAutofailInput:ValidatedText = new ValidatedText(70, 20, ValidatedText.R_INT_P);
                     optionAutofailInput.x = xOff;
                     optionAutofailInput.y = yOff;
                     optionAutofailInput.autofail = judgeTitles[i];
-                    optionAutofailInput.restrict = "0-9";
                     optionAutofailInput.field.maxChars = 5;
                     optionAutofailInput.addEventListener(Event.CHANGE, changeHandler);
                     box.addChild(optionAutofailInput);
@@ -639,11 +632,10 @@ package popups
                 optionAutofailText.y = yOff - 1;
                 box.addChild(optionAutofailText);
 
-                optionAutofailInput = new ValidatedText(70, 20);
+                optionAutofailInput = new ValidatedText(70, 20, ValidatedText.R_FLOAT_P);
                 optionAutofailInput.x = xOff;
                 optionAutofailInput.y = yOff;
                 optionAutofailInput.autofail = "rawGoods";
-                optionAutofailInput.restrict = ".0-9";
                 optionAutofailInput.field.maxChars = 6;
                 optionAutofailInput.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionAutofailInput);
@@ -860,11 +852,10 @@ package popups
                     gameJudgeColor.align = Text.RIGHT;
                     box.addChild(gameJudgeColor);
 
-                    var optionJudgeColor:ValidatedText = new ValidatedText(70, 20);
+                    var optionJudgeColor:ValidatedText = new ValidatedText(70, 20, ValidatedText.R_COLOR);
                     optionJudgeColor.x = xOff + 75;
                     optionJudgeColor.y = yOff;
                     optionJudgeColor.judge_color_id = i;
-                    optionJudgeColor.restrict = "#0-9a-f";
                     optionJudgeColor.field.maxChars = 7;
                     optionJudgeColor.addEventListener(Event.CHANGE, changeHandler);
                     box.addChild(optionJudgeColor);
@@ -910,11 +901,10 @@ package popups
                     gameGameColor.align = Text.RIGHT;
                     box.addChild(gameGameColor);
 
-                    var optionGameColor:ValidatedText = new ValidatedText(70, 20);
+                    var optionGameColor:ValidatedText = new ValidatedText(70, 20, ValidatedText.R_COLOR);
                     optionGameColor.x = xOff + 75;
                     optionGameColor.y = yOff;
                     optionGameColor.game_color_id = i;
-                    optionGameColor.restrict = "#0-9a-f";
                     optionGameColor.field.maxChars = 7;
                     optionGameColor.addEventListener(Event.CHANGE, changeHandler);
                     box.addChild(optionGameColor);
@@ -960,11 +950,10 @@ package popups
                     gameComboColor.align = Text.RIGHT;
                     box.addChild(gameComboColor);
 
-                    var optionComboColor:ValidatedText = new ValidatedText(70, 20);
+                    var optionComboColor:ValidatedText = new ValidatedText(70, 20, ValidatedText.R_COLOR);
                     optionComboColor.x = xOff + 75;
                     optionComboColor.y = yOff;
                     optionComboColor.combo_color_id = i;
-                    optionComboColor.restrict = "#0-9a-f";
                     optionComboColor.field.maxChars = 7;
                     optionComboColor.addEventListener(Event.CHANGE, changeHandler);
                     box.addChild(optionComboColor);
@@ -1053,10 +1042,9 @@ package popups
                 box.addChild(gameIsolationStart);
                 yOff += 20;
 
-                isolationText = new BoxText(100, 20);
+                isolationText = new ValidatedText(100, 20, ValidatedText.R_INT_P);
                 isolationText.x = xOff;
                 isolationText.y = yOff;
-                isolationText.restrict = "0-9";
                 isolationText.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(isolationText);
                 yOff += 30;
@@ -1067,10 +1055,9 @@ package popups
                 box.addChild(gameIsolationtotal);
                 yOff += 20;
 
-                isolationTotalText = new BoxText(100, 20);
+                isolationTotalText = new ValidatedText(100, 20, ValidatedText.R_INT_P);
                 isolationTotalText.x = xOff;
                 isolationTotalText.y = yOff;
-                isolationTotalText.restrict = "0-9";
                 isolationTotalText.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(isolationTotalText);
                 yOff += 80;
@@ -1149,10 +1136,9 @@ package popups
                 box.addChild(gameMPTextSize);
                 yOff += 20;
 
-                optionMPSize = new ValidatedText(100, 20);
+                optionMPSize = new ValidatedText(100, 20, ValidatedText.R_INT_P);
                 optionMPSize.x = xOff;
                 optionMPSize.y = yOff;
-                optionMPSize.restrict = "0-9";
                 optionMPSize.text = "10";
                 optionMPSize.addEventListener(Event.CHANGE, changeHandler);
                 box.addChild(optionMPSize);
@@ -1335,12 +1321,12 @@ package popups
             }
             else if (e.target == isolationText)
             {
-                _avars.configIsolationStart = Math.max(parseInt(isolationText.text) - 1, 0);
+                _avars.configIsolationStart = isolationText.validate(ValidatedText.PARSE_INT, 1, 1) - 1;
                 _avars.configIsolation = _avars.configIsolationStart > 0 || _avars.configIsolationLength > 0;
             }
             else if (e.target == isolationTotalText)
             {
-                _avars.configIsolationLength = Math.max(parseInt(isolationTotalText.text), 0);
+                _avars.configIsolationLength = isolationTotalText.validate(ValidatedText.PARSE_INT, 0);
                 _avars.configIsolation = _avars.configIsolationStart > 0 || _avars.configIsolationLength > 0;
             }
             else if (e.target == optionMPSize)


### PR DESCRIPTION
Resolves #10.

This is a continuation of @Zageron's draft on implementing visual feedback for invalid settings (see #120).