### PR TITLE
Show import and export filter buttons in filter manager

### DIFF
--- a/src/classes/filter/SavedFilterButton.as
+++ b/src/classes/filter/SavedFilterButton.as
@@ -78,16 +78,17 @@ package classes.filter
         {
             defaultCheckbox.removeEventListener(MouseEvent.CLICK, e_defaultClick);
             defaultCheckbox.removeEventListener(MouseEvent.MOUSE_OVER, e_defaultMouseOver);
+            defaultCheckbox.removeEventListener(MouseEvent.MOUSE_OUT, e_defaultMouseOut);
 
             filterName.dispose();
 
             deleteButton.removeEventListener(MouseEvent.CLICK, e_deleteClick);
             deleteButton.dispose();
 
-            editButton.addEventListener(MouseEvent.CLICK, e_editClick);
+            editButton.removeEventListener(MouseEvent.CLICK, e_editClick);
             editButton.dispose();
 
-            exportButton.addEventListener(MouseEvent.CLICK, e_exportClick);
+            exportButton.removeEventListener(MouseEvent.CLICK, e_exportClick);
             exportButton.dispose();
 
             super.dispose();

--- a/src/classes/filter/SavedFilterButton.as
+++ b/src/classes/filter/SavedFilterButton.as
@@ -1,12 +1,14 @@
 package classes.filter
 {
     import assets.GameBackgroundColor;
+    import classes.Alert;
     import classes.Box;
     import classes.BoxButton;
     import classes.BoxCheck;
     import classes.Language;
     import classes.Text;
     import com.flashfla.utils.ArrayUtil;
+    import com.flashfla.utils.SystemUtil;
     import flash.display.DisplayObjectContainer;
     import flash.display.Sprite;
     import flash.events.Event;
@@ -68,7 +70,27 @@ package classes.filter
             exportButton = new BoxButton(100, 23, _lang.string("popup_filter_filter_single_export"));
             exportButton.x = editButton.x - 105;
             exportButton.y = 5;
+            exportButton.addEventListener(MouseEvent.CLICK, e_exportClick);
             addChild(exportButton);
+        }
+
+        override public function dispose():void
+        {
+            defaultCheckbox.removeEventListener(MouseEvent.CLICK, e_defaultClick);
+            defaultCheckbox.removeEventListener(MouseEvent.MOUSE_OVER, e_defaultMouseOver);
+
+            filterName.dispose();
+
+            deleteButton.removeEventListener(MouseEvent.CLICK, e_deleteClick);
+            deleteButton.dispose();
+
+            editButton.addEventListener(MouseEvent.CLICK, e_editClick);
+            editButton.dispose();
+
+            exportButton.addEventListener(MouseEvent.CLICK, e_exportClick);
+            exportButton.dispose();
+
+            super.dispose();
         }
 
         private function e_defaultMouseOver(e:Event):void
@@ -121,6 +143,20 @@ package classes.filter
         {
             if (ArrayUtil.remove(filter, _gvars.activeUser.filters))
                 updater.draw();
+        }
+
+        private function e_exportClick(e:Event):void
+        {
+            var filterString:String = JSON.stringify(filter.export());
+            var success:Boolean = SystemUtil.setClipboard(filterString);
+            if (success)
+            {
+                _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
+            }
+            else
+            {
+                _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
+            }
         }
     }
 }

--- a/src/classes/filter/SavedFilterButton.as
+++ b/src/classes/filter/SavedFilterButton.as
@@ -22,6 +22,7 @@ package classes.filter
         private var updater:PopupFilterManager;
         public var filter:EngineLevelFilter;
         public var filterName:Text;
+        public var exportButton:BoxButton;
         public var editButton:BoxButton;
         public var deleteButton:BoxButton;
         public var defaultCheckbox:BoxCheck;
@@ -63,6 +64,11 @@ package classes.filter
             editButton.y = 5;
             editButton.addEventListener(MouseEvent.CLICK, e_editClick);
             addChild(editButton);
+
+            exportButton = new BoxButton(100, 23, _lang.string("popup_filter_filter_single_export"));
+            exportButton.x = editButton.x - 105;
+            exportButton.y = 5;
+            addChild(exportButton);
         }
 
         private function e_defaultMouseOver(e:Event):void
@@ -116,6 +122,5 @@ package classes.filter
             if (ArrayUtil.remove(filter, _gvars.activeUser.filters))
                 updater.draw();
         }
-
     }
 }


### PR DESCRIPTION
Importing and exporting filters were previously done by right-clicking the 'Add Filter' and 'Select / Edit' buttons of a filter respectively and clicking the corresponding context menu option. These options are now exposed as buttons in the filter manager for easier access.