### PR TITLE
Display foreign fonts correctly

### DIFF
--- a/fonts/NotoSans/src/NotoSans.as
+++ b/fonts/NotoSans/src/NotoSans.as
@@ -20,11 +20,10 @@ package
         // "U+0400-U+04FF" // Cyrillic
         // "U+0500-U+052F" // Cyrillic Supplement
 
-        [Embed(source = '../assets/NotoSans-CJK-Bold.ttc', fontFamily = 'Noto Sans CJK JP Bold', unicodeRange = "U+4E00-U+62FF,U+6300-U+77FF,U+7800-U+8CFF,U+8D00-U+9FFF,U+30A0-U+30FF,U+3040-U+309F,U+0020-U+007E,U+00A0-U+00FF,U+0100-U+017F,U+0180-U+024F,U+0400-U+04FF,U+0500-U+052F", fontStyle = 'normal', fontWeight = 'bold', mimeType = "application/x-font", advancedAntiAliasing = true, embedAsCFF = false)]
+        [Embed(source = '../assets/NotoSans-CJK-Bold.ttc', fontFamily = 'Noto Sans CJK JP Bold', fontStyle = 'normal', fontWeight = 'bold', mimeType = "application/x-font", advancedAntiAliasing = true, embedAsCFF = false)]
         public static var CJKBold:Class;
 
         [Embed(source = '../assets/NotoSans-Bold.ttf', fontFamily = 'Noto Sans Bold', fontStyle = 'normal', fontWeight = 'bold', mimeType = "application/x-font", advancedAntiAliasing = true, embedAsCFF = false)]
         public static var Bold:Class;
     }
-
 }

--- a/src/com/bit101/components/Style.as
+++ b/src/com/bit101/components/Style.as
@@ -30,83 +30,83 @@
 package com.bit101.components
 {
 
-	import classes.Language;
+    import classes.Language;
 
-	public class Style
-	{
-		public static var TEXT_BACKGROUND:uint = 0xFFFFFF;
-		public static var BACKGROUND:uint = 0xCCCCCC;
-		public static var BUTTON_FACE:uint = 0xFFFFFF;
-		public static var BUTTON_DOWN:uint = 0xEEEEEE;
-		public static var INPUT_TEXT:uint = 0x333333;
-		public static var LABEL_TEXT:uint = 0x666666;
-		public static var DROPSHADOW:uint = 0x000000;
-		public static var PANEL:uint = 0xF3F3F3;
-		public static var PROGRESS_BAR:uint = 0xFFFFFF;
-		public static var LIST_DEFAULT:uint = 0xFFFFFF;
-		public static var LIST_ALTERNATE:uint = 0xF3F3F3;
-		public static var LIST_SELECTED:uint = 0xCCCCCC;
-		public static var LIST_ROLLOVER:uint = 0XDDDDDD;
-		
-		public static var embedFonts:Boolean = true;
-		public static var fontName:String = Language.FONT_NAME; //"Arial Unicode MS Bold";
-		public static var fontSize:Number = 8;
-		
-		public static const DARK:String = "dark";
-		public static const LIGHT:String = "light";
-		public static const FFR:String = "ffr";
-		
-		/**
-		 * Applies a preset style as a list of color values. Should be called before creating any components.
-		 */
-		public static function setStyle(style:String):void
-		{
-			switch(style)
-			{
-				case FFR:
-					Style.BACKGROUND = 0xBFDFFF;
-					Style.BUTTON_FACE = 0x397286;
-					Style.BUTTON_DOWN = 0x326171;
-					Style.INPUT_TEXT = 0x333333;
-					Style.LABEL_TEXT = 0xFFFFFF;
-					Style.PANEL = 0x608b9b;
-					Style.PROGRESS_BAR = 0xFFFFFF;
-					Style.TEXT_BACKGROUND = 0x608b9b;
-					Style.LIST_DEFAULT = 0x608b9b;
-					Style.LIST_ALTERNATE = 0x5f8a9a;
-					Style.LIST_SELECTED = 0x7da2b0;
-					Style.LIST_ROLLOVER = 0x9dbbc6;
-					break;
-				case DARK:
-					Style.BACKGROUND = 0x444444;
-					Style.BUTTON_FACE = 0x666666;
-					Style.BUTTON_DOWN = 0x222222;
-					Style.INPUT_TEXT = 0xBBBBBB;
-					Style.LABEL_TEXT = 0xCCCCCC;
-					Style.PANEL = 0x666666;
-					Style.PROGRESS_BAR = 0x666666;
-					Style.TEXT_BACKGROUND = 0x555555;
-					Style.LIST_DEFAULT = 0x444444;
-					Style.LIST_ALTERNATE = 0x393939;
-					Style.LIST_SELECTED = 0x666666;
-					Style.LIST_ROLLOVER = 0x777777;
-					break;
-				case LIGHT:
-				default:
-					Style.BACKGROUND = 0xCCCCCC;
-					Style.BUTTON_FACE = 0xFFFFFF;
-					Style.BUTTON_DOWN = 0xEEEEEE;
-					Style.INPUT_TEXT = 0x333333;
-					Style.LABEL_TEXT = 0x666666;
-					Style.PANEL = 0xF3F3F3;
-					Style.PROGRESS_BAR = 0xFFFFFF;
-					Style.TEXT_BACKGROUND = 0xFFFFFF;
-					Style.LIST_DEFAULT = 0xFFFFFF;
-					Style.LIST_ALTERNATE = 0xF3F3F3;
-					Style.LIST_SELECTED = 0xCCCCCC;
-					Style.LIST_ROLLOVER = 0xDDDDDD;
-					break;
-			}
-		}
-	}
+    public class Style
+    {
+        public static var TEXT_BACKGROUND:uint = 0xFFFFFF;
+        public static var BACKGROUND:uint = 0xCCCCCC;
+        public static var BUTTON_FACE:uint = 0xFFFFFF;
+        public static var BUTTON_DOWN:uint = 0xEEEEEE;
+        public static var INPUT_TEXT:uint = 0x333333;
+        public static var LABEL_TEXT:uint = 0x666666;
+        public static var DROPSHADOW:uint = 0x000000;
+        public static var PANEL:uint = 0xF3F3F3;
+        public static var PROGRESS_BAR:uint = 0xFFFFFF;
+        public static var LIST_DEFAULT:uint = 0xFFFFFF;
+        public static var LIST_ALTERNATE:uint = 0xF3F3F3;
+        public static var LIST_SELECTED:uint = 0xCCCCCC;
+        public static var LIST_ROLLOVER:uint = 0XDDDDDD;
+
+        public static var embedFonts:Boolean = true;
+        public static var fontName:String = Language.UNI_FONT_NAME; //"Arial Unicode MS Bold";
+        public static var fontSize:Number = 8;
+
+        public static const DARK:String = "dark";
+        public static const LIGHT:String = "light";
+        public static const FFR:String = "ffr";
+
+        /**
+         * Applies a preset style as a list of color values. Should be called before creating any components.
+         */
+        public static function setStyle(style:String):void
+        {
+            switch (style)
+            {
+                case FFR:
+                    Style.BACKGROUND = 0xBFDFFF;
+                    Style.BUTTON_FACE = 0x397286;
+                    Style.BUTTON_DOWN = 0x326171;
+                    Style.INPUT_TEXT = 0x333333;
+                    Style.LABEL_TEXT = 0xFFFFFF;
+                    Style.PANEL = 0x608b9b;
+                    Style.PROGRESS_BAR = 0xFFFFFF;
+                    Style.TEXT_BACKGROUND = 0x608b9b;
+                    Style.LIST_DEFAULT = 0x608b9b;
+                    Style.LIST_ALTERNATE = 0x5f8a9a;
+                    Style.LIST_SELECTED = 0x7da2b0;
+                    Style.LIST_ROLLOVER = 0x9dbbc6;
+                    break;
+                case DARK:
+                    Style.BACKGROUND = 0x444444;
+                    Style.BUTTON_FACE = 0x666666;
+                    Style.BUTTON_DOWN = 0x222222;
+                    Style.INPUT_TEXT = 0xBBBBBB;
+                    Style.LABEL_TEXT = 0xCCCCCC;
+                    Style.PANEL = 0x666666;
+                    Style.PROGRESS_BAR = 0x666666;
+                    Style.TEXT_BACKGROUND = 0x555555;
+                    Style.LIST_DEFAULT = 0x444444;
+                    Style.LIST_ALTERNATE = 0x393939;
+                    Style.LIST_SELECTED = 0x666666;
+                    Style.LIST_ROLLOVER = 0x777777;
+                    break;
+                case LIGHT:
+                default:
+                    Style.BACKGROUND = 0xCCCCCC;
+                    Style.BUTTON_FACE = 0xFFFFFF;
+                    Style.BUTTON_DOWN = 0xEEEEEE;
+                    Style.INPUT_TEXT = 0x333333;
+                    Style.LABEL_TEXT = 0x666666;
+                    Style.PANEL = 0xF3F3F3;
+                    Style.PROGRESS_BAR = 0xFFFFFF;
+                    Style.TEXT_BACKGROUND = 0xFFFFFF;
+                    Style.LIST_DEFAULT = 0xFFFFFF;
+                    Style.LIST_ALTERNATE = 0xF3F3F3;
+                    Style.LIST_SELECTED = 0xCCCCCC;
+                    Style.LIST_ROLLOVER = 0xDDDDDD;
+                    break;
+            }
+        }
+    }
 }

--- a/src/popups/PopupCustomNoteskin.as
+++ b/src/popups/PopupCustomNoteskin.as
@@ -284,7 +284,7 @@ package popups
         {
             LocalStore.setVariable("custom_noteskin", noteskinsString(), 20971520); // 20MB Mins size requested.
             Noteskins.instance.loadCustomNoteskin();
-            GlobalVariables.instance.gameMain.addAlert(_lang.stringSimple("popup_noteskin_saved"), 90, Alert.GREEN);
+            GlobalVariables.instance.gameMain.addAlert(_lang.string("popup_noteskin_saved"), 90, Alert.GREEN);
         }
 
         private function exportNoteskin():void


### PR DESCRIPTION
Bugs fixed:
- Previously, the Noto Sans font had a restriction on what Unicode characters it could display, which would make certain foreign language characters from translated strings to not be shown. This restriction is now removed, and these characters should be shown now.
- bit101 components were using a non-Unicode font that made a lot of Unicode characters unable to be displayed. They now use a Unicode font.
- The alerts in the custom noteskin menu should now display translated strings correctly.