### PR TITLE
Make File Paths on other OS work.

### DIFF
--- a/src/AirContext.as
+++ b/src/AirContext.as
@@ -3,6 +3,7 @@ package
     import by.blooddy.crypto.MD5;
     import classes.FileTracker;
     import classes.chart.Song;
+    import com.flashfla.utils.SystemUtil;
     import flash.events.Event;
     import flash.events.IOErrorEvent;
     import flash.events.SecurityErrorEvent;
@@ -18,6 +19,14 @@ package
      */
     public class AirContext
     {
+        // Windows will store files in the current folder, other OS will use the application storage folder.
+        public static var STORAGE_PATH:File = File.applicationDirectory;
+        {
+            if (SystemUtil.OS.toLowerCase().indexOf("win") == -1)
+            {
+                STORAGE_PATH = File.applicationStorageDirectory;
+            }
+        }
 
         static public function serverVersionHigher(serverVersionString:String):int
         {
@@ -100,19 +109,17 @@ package
 
         static public function getAppFile(path:String):File
         {
-            return new File("app:/" + path);
+            return STORAGE_PATH.resolvePath(path);
         }
 
         static public function getAppPath(path:String):String
         {
-            var tf:File = new File("app:/" + path);
-            return tf.nativePath;
+            return STORAGE_PATH.resolvePath(path).nativePath;
         }
 
         static public function doesFileExist(path:String):Boolean
         {
-            var tf:File = new File("app:/" + path);
-            return tf.exists;
+            return STORAGE_PATH.resolvePath(path).exists;
         }
 
         static public function writeFile(appPath:String, bytes:ByteArray, key:uint = 0, errorCallback:Function = null):File

--- a/src/Main.as
+++ b/src/Main.as
@@ -106,8 +106,6 @@ package
             //- Set GlobalVariables Stage
             _gvars.gameMain = this;
 
-            SystemUtil.init();
-
             if (stage)
             {
                 //- Set up vSync

--- a/src/com/flashfla/utils/SystemUtil.as
+++ b/src/com/flashfla/utils/SystemUtil.as
@@ -7,17 +7,15 @@ package com.flashfla.utils
 
     public class SystemUtil
     {
+        public static var versionArray:Array;
         public static var OS:String;
         public static var flashMajorVersion:int;
         public static var flashMinorVersion:int;
         public static var flashBuildVersion:int;
 
-        private static var isLoaded:Boolean = false;
-
-        public static function init():void
         {
             // Get the player’s version by using the flash.system.Capabilities class.
-            var versionArray:Array = StringUtil.splitMultiple(Capabilities.version, [" ", ","]);
+            versionArray = StringUtil.splitMultiple(Capabilities.version, [" ", ","]);
 
             //versionArray = ["WIN", 9, 0, 0];
 
@@ -25,51 +23,11 @@ package com.flashfla.utils
             flashMajorVersion = parseInt(versionArray[1]);
             flashMinorVersion = parseInt(versionArray[2]);
             flashBuildVersion = parseInt(versionArray[3]);
-            isLoaded = true;
-        }
-
-        public static function getMajorVersion():int
-        {
-            return flashMajorVersion;
-        }
-
-        public static function getMinorVersion():int
-        {
-            return flashMinorVersion;
-        }
-
-        public static function getBuildVersion():int
-        {
-            return flashBuildVersion;
-        }
-
-        public static function getOS():String
-        {
-            return OS;
         }
 
         public static function getFlashVersion():Object
         {
-            return {os: OS, major: flashMajorVersion, minor: flashMinorVersion, build: flashBuildVersion};
-        }
-
-        public static function isFlashNewerThan(major:int, minor:int = 0, build:int = 0):Boolean
-        {
-            if (flashMajorVersion > major)
-                return true;
-            if (flashMajorVersion < major)
-                return false;
-
-            if (minor <= 0)
-                return true;
-            if (flashMinorVersion < minor)
-                return false;
-            if (build <= 0)
-                return true;
-            if (flashBuildVersion >= build)
-                return true;
-
-            return false;
+            return {"os": OS, "major": flashMajorVersion, "minor": flashMinorVersion, "build": flashBuildVersion};
         }
 
         public static function gc():void


### PR DESCRIPTION
Uses the application storage folder instead of the current application folder. This should fix possible issues with Mac builds in the future.

Also removes the need to call init() on SystemUtil class and remove unneeded functions that are also exposed as variables.
