### PR TITLE
Remove linebreaks between `README.md` badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![Latest Release][latest-release-badge]](https://github.com/flashflashrevolution/rCubed/releases)
-
 ![Platform Support][platforms-badge]
-
 ![Release][release-status-badge]
-
 ![Master][master-status-badge]
-
 [![FFR Discord][discord-badge]](https://discord.gg/ffr)
 
 ---


### PR DESCRIPTION
Left the `contributors` badge alone as I'm unsure if that would break automated updates to it.