### PR TITLE
Add combo colour for raw goods

### DIFF
--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -94,7 +94,7 @@ package classes
         public var DISPLAY_MP_MASK:Boolean = false;
         public var DISPLAY_MP_TIMESTAMP:Boolean = false;
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000, 0xDCC200]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag, RawGood
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000, 0xDC00C2]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag, RawGood
         public var enableComboColors:Array = [true, true, true, false, false, false, false, false, false];
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteColours:Object = ["red", "blue", "purple", "yellow", "pink", "orange", "cyan", "green", "white"];

--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -94,10 +94,11 @@ package classes
         public var DISPLAY_MP_MASK:Boolean = false;
         public var DISPLAY_MP_TIMESTAMP:Boolean = false;
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag
-        public var enableComboColors:Array = [true, true, true, false, false, false, false, false];
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000, 0xDCC200]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag, RawGood
+        public var enableComboColors:Array = [true, true, true, false, false, false, false, false, false];
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteColours:Object = ["red", "blue", "purple", "yellow", "pink", "orange", "cyan", "green", "white"];
+        public var rawGoodTracker:Number = 0;
 
         public var autofailAmazing:int = 0;
         public var autofailPerfect:int = 0;
@@ -561,6 +562,8 @@ package classes
                 this.gameColours = _settings.gameColours;
             if (_settings.noteColours != null)
                 this.noteColours = _settings.noteColours;
+            if (_settings.rawGoodTracker != null)
+                this.rawGoodTracker = _settings.rawGoodTracker;
             if (_settings.gameVolume != null)
                 this.gameVolume = _settings.gameVolume;
             if (_settings.isolationOffset != null)
@@ -648,6 +651,7 @@ package classes
             gameSave.enableComboColors = this.enableComboColors;
             gameSave.gameColours = this.gameColours;
             gameSave.noteColours = this.noteColours;
+            gameSave.rawGoodTracker = this.rawGoodTracker;
             gameSave.songQueues = this.songQueues;
             gameSave.gameVolume = this.gameVolume;
             gameSave.filters = doExportFilters(this.filters);

--- a/src/game/GameOptions.as
+++ b/src/game/GameOptions.as
@@ -47,7 +47,7 @@ package game
         public var displayMPCombo:Boolean = true;
 
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000, 0xDCC200]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag, RawGood
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000, 0xDC00C2]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag, RawGood
         public var enableComboColors:Array = [true, true, true, false, false, false, false, false, false];
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteDirections:Array = ["D", "L", "U", "R"];

--- a/src/game/GameOptions.as
+++ b/src/game/GameOptions.as
@@ -47,12 +47,13 @@ package game
         public var displayMPCombo:Boolean = true;
 
         public var judgeColours:Array = [0x78ef29, 0x12e006, 0x01aa0f, 0xf99800, 0xfe0000, 0x804100];
-        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag
-        public var enableComboColors:Array = [true, true, true, false, false, false, false, false];
+        public var comboColours:Array = [0x0099CC, 0x00AD00, 0xFCC200, 0xC7FB30, 0x6C6C6C, 0xF99800, 0xB06100, 0x990000, 0xDCC200]; // Normal, FC, AAA, SDG, BlackFlag, AvFlag, BooFlag, MissFlag, RawGood
+        public var enableComboColors:Array = [true, true, true, false, false, false, false, false, false];
         public var gameColours:Array = [0x1495BD, 0x033242, 0x0C6A88, 0x074B62];
         public var noteDirections:Array = ["D", "L", "U", "R"];
         public var noteColors:Array = ["red", "blue", "purple", "yellow", "pink", "orange", "cyan", "green", "white"];
         public var noteSwapColours:Object = {"red": "red", "blue": "blue", "purple": "purple", "yellow": "yellow", "pink": "pink", "orange": "orange", "cyan": "cyan", "green": "green", "white": "white"};
+        public var rawGoodTracker:Number = 0;
 
         public var layout:Object = {};
 
@@ -120,6 +121,7 @@ package game
             comboColours = user.comboColours.concat();
             enableComboColors = user.enableComboColors.concat();
             gameColours = user.gameColours.concat();
+            rawGoodTracker = user.rawGoodTracker;
 
             for (var i:int = 0; i < noteColors.length; i++)
             {

--- a/src/game/controls/Combo.as
+++ b/src/game/controls/Combo.as
@@ -86,6 +86,7 @@ package game.controls
                [5] = Average Flag,
                [6] = Boo Flag,
                [7] = Miss Flag
+               [8] = Raw Goods
              */
 
             if (options && (!options.isAutoplay || options.isEditor || options.multiplayer))
@@ -119,6 +120,11 @@ package game.controls
                 {
                     field.textColor = colors[3];
                     fieldShadow.textColor = colors_dark[3];
+                }
+                else if (colors_enabled[8] && raw_goods <= options.rawGoodTracker) // Display color for raw good tracker
+                {
+                    field.textColor = colors[8];
+                    fieldShadow.textColor = colors_dark[8];
                 }
                 else if (colors_enabled[1] && miss == 0) // Display green for FC
                 {

--- a/src/game/controls/Combo.as
+++ b/src/game/controls/Combo.as
@@ -116,15 +116,15 @@ package game.controls
                     field.textColor = colors[7];
                     fieldShadow.textColor = colors_dark[7];
                 }
-                else if (colors_enabled[3] && raw_goods < 10) // Display SDG color if raw goods < 10
-                {
-                    field.textColor = colors[3];
-                    fieldShadow.textColor = colors_dark[3];
-                }
                 else if (colors_enabled[8] && raw_goods <= options.rawGoodTracker) // Display color for raw good tracker
                 {
                     field.textColor = colors[8];
                     fieldShadow.textColor = colors_dark[8];
+                }
+                else if (colors_enabled[3] && raw_goods < 10) // Display SDG color if raw goods < 10
+                {
+                    field.textColor = colors[3];
+                    fieldShadow.textColor = colors_dark[3];
                 }
                 else if (colors_enabled[1] && miss == 0) // Display green for FC
                 {

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -749,7 +749,7 @@ package popups
                 var gameRawGoodTracker:Text = new Text(box, xOff, yOff, _lang.string("options_raw_goods_tracker"));
                 gameRawGoodTracker.width = 70;
                 gameRawGoodTracker.align = Text.RIGHT;
-                optionRawGoodTracker = new ValidatedText(box, xOff + 75, yOff, 70, 20, ValidatedText.R_INT_P, changeHandler)
+                optionRawGoodTracker = new ValidatedText(box, xOff + 75, yOff, 70, 20, ValidatedText.R_FLOAT_P, changeHandler)
 
                 ///- Col 3
                 xOff += 245;

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -141,6 +141,7 @@ package popups
         private var optionComboColorCheck:BoxCheck;
         private var optionGameColors:Array;
         private var optionNoteColors:Array;
+        private var optionRawGoodTracker:ValidatedText;
 
         private var isolationText:ValidatedText;
         private var isolationTotalText:ValidatedText;
@@ -745,6 +746,11 @@ package popups
                     yOff += 25;
                 }
 
+                var gameRawGoodTracker:Text = new Text(box, xOff, yOff, _lang.string("options_raw_goods_tracker"));
+                gameRawGoodTracker.width = 70;
+                gameRawGoodTracker.align = Text.RIGHT;
+                optionRawGoodTracker = new ValidatedText(box, xOff + 75, yOff, 70, 20, ValidatedText.R_INT_P, changeHandler)
+
                 ///- Col 3
                 xOff += 245;
                 yOff = BASE_Y_POSITION;
@@ -1013,6 +1019,10 @@ package popups
             {
                 Style.fontSize = _avars.configMPSize = optionMPSize.validate(10);
                 _avars.mpSave();
+            }
+            else if (e.target == optionRawGoodTracker)
+            {
+                _gvars.activeUser.rawGoodTracker = optionRawGoodTracker.validate(0, 0);
             }
             else if (e.target.hasOwnProperty("autofail"))
             {
@@ -1791,6 +1801,10 @@ package popups
                         optionComboColors[i]["enable"].checked = (_gvars.activeUser.enableComboColors[i]);
                     }
                 }
+
+                // Set Raw Good Tracker
+                optionRawGoodTracker.text = _gvars.activeUser.rawGoodTracker.toString();
+
                 // Set Game Colors
                 for (i = 0; i < DEFAULT_OPTIONS.gameColours.length; i++)
                 {


### PR DESCRIPTION
Adds combo coloring for raw goods using a user defined value resolving #228 . 

`<Message id="options_combo_colors_8">
  <text>Raw Goods</text>
</Message>` and
`<Message id="options_raw_goods_tracker">
  <text>Raw Goods Tracker</text>
</Message>`
Need to be added to game/r3/r3-language.php along with translations