### PR TITLE
Fixes warning in console about finding a function while expecting a boolean

### DIFF
--- a/src/classes/ui/ValidatedText.as
+++ b/src/classes/ui/ValidatedText.as
@@ -67,7 +67,7 @@ package classes.ui
                     break;
             }
 
-            if (listener)
+            if (listener != null)
             {
                 this._listener = listener;
                 this.addEventListener(Event.CHANGE, listener);


### PR DESCRIPTION
Only affects Hybrid Builds / Flex 4.6 SDK.