### PR TITLE
Update Air SDK URL to fixed version.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
         if: matrix.os == 'windows-latest' && steps.cache-air-sdk.outputs.cache-hit != 'true'
         run: |
           $ProgressPreference = 'SilentlyContinue';
-          (irm -Uri "http://airdownload.adobe.com/air/win/download/latest/AIRSDK_Compiler.zip" -ContentType "application/octet-stream" -OutFile "air-sdk.zip")
+          (irm -Uri "http://airdownload.adobe.com/air/win/download/32.0/AIRSDK_Compiler.zip" -ContentType "application/octet-stream" -OutFile "air-sdk.zip")
 
       - name: extract-7z-action
         if: matrix.os == 'windows-latest' && steps.cache-air-sdk.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         if: matrix.os == 'windows-latest' && steps.cache-air-sdk.outputs.cache-hit != 'true'
         run: |
           $ProgressPreference = 'SilentlyContinue';
-          (irm -Uri "http://airdownload.adobe.com/air/win/download/latest/AIRSDK_Compiler.zip" -ContentType "application/octet-stream" -OutFile "air-sdk.zip")
+          (irm -Uri "http://airdownload.adobe.com/air/win/download/32.0/AIRSDK_Compiler.zip" -ContentType "application/octet-stream" -OutFile "air-sdk.zip")
 
       - name: extract-7z-action
         if: matrix.os == 'windows-latest' && steps.cache-air-sdk.outputs.cache-hit != 'true'


### PR DESCRIPTION
`latest` no longer resolves to the correct url, while direct version url still continues to work.

Without this fix, all other builds will fail due to missing sdk.