### PR TITLE
Use full commit SHA hash for workflows

### DIFF
--- a/.github/workflows/pull-request-notification.yml
+++ b/.github/workflows/pull-request-notification.yml
@@ -11,6 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.1
         
-      - uses: Ilshidur/action-discord@759f6ea
+      - uses: Ilshidur/action-discord@759f6ea4dc493b8bd1bb35ae7fbd7ae10fcea129
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
Shortened commit SHA hashes are no longer supported, causing workflows that rely on them to fail. Use the full commit SHA hash instead.