### PR TITLE
Refactor Alerts

### DIFF
--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -9,7 +9,9 @@ package
     import be.aboutme.airserver.endpoints.socket.handlers.websocket.WebSocketClientHandlerFactory;
     import be.aboutme.airserver.messages.Message;
     import by.blooddy.crypto.image.PNGEncoder;
+    import classes.Alert;
     import classes.Playlist;
+    import classes.SongInfo;
     import classes.SongPlayerBytes;
     import classes.StatTracker;
     import classes.User;
@@ -36,7 +38,6 @@ package
     import flash.utils.ByteArray;
     import game.GameOptions;
     import game.GameScoreResult;
-    import classes.SongInfo;
 
     public class GlobalVariables extends EventDispatcher
     {
@@ -525,7 +526,7 @@ package
             }
             catch (e:Error)
             {
-                gameMain.addAlert("ERROR: Unable to save image.", 120);
+                Alert.add("ERROR: Unable to save image.", 120);
             }
         }
 

--- a/src/LoginMenu.as
+++ b/src/LoginMenu.as
@@ -1,5 +1,6 @@
 package
 {
+    import classes.Alert;
     import classes.Language;
     import classes.Playlist;
     import classes.ui.Box;
@@ -282,7 +283,7 @@ package
             if (_data.result == 4)
             {
                 isLoading = false;
-                _gvars.gameMain.addAlert(_lang.string("login_invalid_session"));
+                Alert.add(_lang.string("login_invalid_session"));
                 changeUserEvent(e);
             }
             else if (_data.result >= 1 && _data.result <= 3)

--- a/src/Main.as
+++ b/src/Main.as
@@ -83,8 +83,6 @@ package
         public var retryLoadButton:BoxButton;
         public var disablePopups:Boolean = false;
 
-        private var activeAlert:Alert;
-        private var alertsQueue:Array = [];
         private var popupQueue:Array = [];
         private var lastPanel:MenuPanel;
         public var activePanel:MenuPanel;
@@ -141,6 +139,9 @@ package
             {
                 this.removeEventListener(Event.ADDED_TO_STAGE, gameInit);
             }
+
+            //- Static Class Init
+            Alert.init(stage);
 
             //- Setup Tween Override mode
             TweenPlugin.activate([TintPlugin, AutoAlphaPlugin]);
@@ -242,7 +243,7 @@ package
             //- No Reason
             CONFIG::debug
             {
-                addAlert("Development Build - " + CONFIG::timeStamp + " - NOT FOR RELEASE", 120, Alert.RED);
+                Alert.add("Development Build - " + CONFIG::timeStamp + " - NOT FOR RELEASE", 120, Alert.RED);
             }
         }
 
@@ -458,7 +459,7 @@ package
 
         private function e_retryClick(e:Event):void
         {
-            addAlert("Reloading incomplete scripts...");
+            Alert.add("Reloading incomplete scripts...");
             if (!_playlist.isLoaded())
             {
                 _playlist.addEventListener(GlobalVariables.LOAD_COMPLETE, gameScriptLoad);
@@ -703,52 +704,6 @@ package
                     this.removeChildAt(i);
                     break;
                 }
-            }
-        }
-
-        ///- Game Alerts
-        public function addAlert(message:String, age:int = 120, color:uint = 0x000000):void
-        {
-            if (activeAlert == null)
-            {
-                activeAlert = new Alert(message, age, color);
-                activeAlert.x = GAME_WIDTH - activeAlert.width - 5;
-                activeAlert.y = GAME_HEIGHT - activeAlert.height - 5;
-                this.addChild(activeAlert);
-
-                this.addEventListener(Event.ENTER_FRAME, alertOnFrame);
-            }
-            else
-            {
-                alertsQueue.push({ms: message, ag: age, col: color});
-            }
-        }
-
-        private function alertOnFrame(e:Event):void
-        {
-            // Progress Active Alert
-            if (activeAlert)
-            {
-                activeAlert.progress();
-                if (activeAlert.time > activeAlert.age)
-                {
-                    this.removeChild(activeAlert);
-                    activeAlert = null;
-                    this.removeEventListener(Event.ENTER_FRAME, alertOnFrame);
-                }
-            }
-
-            // Add new alert if the old alert is finished
-            if (activeAlert == null && alertsQueue.length >= 1)
-            {
-                var newAlert:Object = alertsQueue.splice(0, 1)[0];
-                addAlert(newAlert.ms, newAlert.ag, newAlert.col);
-            }
-
-            // General cleanup in case
-            if (activeAlert == null && alertsQueue.length == 0)
-            {
-                this.removeEventListener(Event.ENTER_FRAME, alertOnFrame);
             }
         }
 

--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -4,26 +4,27 @@ package arc.mp
     import arc.mp.ListItemDoubleClick;
     import arc.mp.MultiplayerChat;
     import arc.mp.MultiplayerUsers;
+    import classes.Alert;
+    import classes.Room;
+    import classes.User;
     import classes.ui.BoxButton;
     import classes.ui.MPCreateRoomPrompt;
     import classes.ui.Prompt;
     import classes.ui.Text;
     import classes.ui.Throbber;
-    import classes.Room;
-    import classes.User;
     import com.bit101.components.List;
     import com.bit101.components.PushButton;
     import com.bit101.components.Style;
     import com.bit101.components.Window;
     import com.flashfla.net.Multiplayer;
-    import com.flashfla.net.events.ServerMessageEvent;
     import com.flashfla.net.events.ConnectionEvent;
     import com.flashfla.net.events.LoginEvent;
     import com.flashfla.net.events.RoomJoinedEvent;
     import com.flashfla.net.events.RoomLeftEvent;
     import com.flashfla.net.events.RoomListEvent;
-    import com.flashfla.net.events.RoomUserStatusEvent;
     import com.flashfla.net.events.RoomUpdateEvent;
+    import com.flashfla.net.events.RoomUserStatusEvent;
+    import com.flashfla.net.events.ServerMessageEvent;
     import flash.events.ContextMenuEvent;
     import flash.events.Event;
     import flash.events.MouseEvent;
@@ -160,7 +161,7 @@ package arc.mp
 
         private function onServerMessageEvent(event:ServerMessageEvent):void
         {
-            GlobalVariables.instance.gameMain.addAlert("Server Message: " + event.message);
+            Alert.add("Server Message: " + event.message);
         }
 
         private function onConnectionEvent(event:ConnectionEvent):void

--- a/src/arc/mp/MultiplayerSingleton.as
+++ b/src/arc/mp/MultiplayerSingleton.as
@@ -1,25 +1,27 @@
 package arc.mp
 {
     import arc.mp.MultiplayerPanel;
+
+    import classes.Alert;
+    import classes.Gameplay;
     import classes.Playlist;
     import classes.Room;
-    import classes.User;
     import classes.SongInfo;
-    import classes.Gameplay;
+    import classes.User;
     import classes.chart.Song;
     import classes.replay.Replay;
     import com.flashfla.net.Multiplayer;
-    import com.flashfla.net.events.ErrorEvent;
     import com.flashfla.net.events.ConnectionEvent;
-    import com.flashfla.net.events.LoginEvent;
-    import com.flashfla.net.events.RoomListEvent;
-    import com.flashfla.net.events.RoomJoinedEvent;
-    import com.flashfla.net.events.RoomLeftEvent;
-    import com.flashfla.net.events.RoomUserEvent;
-    import com.flashfla.net.events.MessageEvent;
+    import com.flashfla.net.events.ErrorEvent;
     import com.flashfla.net.events.GameResultsEvent;
     import com.flashfla.net.events.GameStartEvent;
     import com.flashfla.net.events.GameUpdateEvent;
+    import com.flashfla.net.events.LoginEvent;
+    import com.flashfla.net.events.MessageEvent;
+    import com.flashfla.net.events.RoomJoinedEvent;
+    import com.flashfla.net.events.RoomLeftEvent;
+    import com.flashfla.net.events.RoomListEvent;
+    import com.flashfla.net.events.RoomUserEvent;
     import com.flashfla.net.events.RoomUserStatusEvent;
     import com.flashfla.utils.StringUtil;
     import flash.events.Event;
@@ -108,7 +110,7 @@ package arc.mp
 
         private function onError(event:ErrorEvent):void
         {
-            _gvars.gameMain.addAlert("MP Error: " + event.message);
+            Alert.add("MP Error: " + event.message);
         }
 
         private function onConnection(event:ConnectionEvent):void
@@ -167,13 +169,13 @@ package arc.mp
         private function updateRoomUser(room:Room, user:User):void
         {
             if (user != null && room.isGameRoom && user.id != currentUser.id && room.isPlayer(currentUser) && room.isPlayer(user))
-                _gvars.gameMain.addAlert("A Challenger Appears! " + user.name);
+                Alert.add("A Challenger Appears! " + user.name);
         }
 
         private function onMessage(event:MessageEvent):void
         {
             if (event.msgType == Multiplayer.MESSAGE_PRIVATE)
-                _gvars.gameMain.addAlert("*** " + event.user.name + ": " + event.message);
+                Alert.add("*** " + event.user.name + ": " + event.message);
         }
 
         private function forEachRoom(func:Function):void
@@ -341,7 +343,7 @@ package arc.mp
                         if (currentSongFile && currentSongFile.loadFail)
                         {
                             _gvars.removeSongFile(currentSongFile);
-                            _gvars.gameMain.addAlert(currentSongInfo.name + " failed to load");
+                            Alert.add(currentSongInfo.name + " failed to load");
                             currentSongFile = null;
                             currentStatus = Multiplayer.STATUS_PICKING;
                             timer.stop();

--- a/src/classes/Alert.as
+++ b/src/classes/Alert.as
@@ -1,66 +1,157 @@
 package classes
 {
     import flash.display.Sprite;
-    import flash.text.AntiAliasType;
-    import flash.text.TextField;
-    import flash.text.TextFieldAutoSize;
+    import flash.display.Stage;
+    import flash.events.Event;
 
-    public class Alert extends Sprite
+    public class Alert
     {
         public static const RED:uint = 0x6D0E0E;
         public static const GREEN:uint = 0x116D0E;
         public static const DARK_GREEN:uint = 0x084400;
         public static const BLUE:uint = 0x0E3F6D;
 
-        public var message:String;
-        public var age:int = 120;
-        public var time:int = 0;
+        public static var STAGE_REF:Stage;
 
-        private var _textfield:TextField;
+        private static var ALERT_DISPLAY:AlertDisplay;
+        private static var ALERT_QUEUE:Array = [];
+        private static var HAS_EVENT:Boolean = false;
 
-        public function Alert(message:String, age:int = 120, color:uint = 0x000000)
+        public static function init(ref:Stage):void
         {
-            this.mouseEnabled = false;
-            this.mouseChildren = false;
-
-            this.message = message;
-            this.age = age;
-
-            _textfield = new TextField();
-            _textfield.x = 6;
-            _textfield.y = 2;
-            _textfield.selectable = false;
-            _textfield.embedFonts = true;
-            _textfield.antiAliasType = AntiAliasType.ADVANCED;
-            _textfield.autoSize = TextFieldAutoSize.LEFT;
-            _textfield.defaultTextFormat = Constant.TEXT_FORMAT;
-            _textfield.htmlText = message;
-
-            this.graphics.lineStyle(1, 0xFFFFFF, 2, true);
-            this.graphics.beginFill(color, 0.75);
-            this.graphics.drawRect(0, 0, _textfield.width + 13, _textfield.height + 5);
-            this.graphics.endFill();
-
-            this.addChild(_textfield);
-
-            this.alpha = 0;
+            STAGE_REF = ref;
+            ALERT_DISPLAY = new AlertDisplay();
         }
 
-        public function progress():void
+        public static function add(message:String, age:int = 120, color:uint = 0x000000):void
         {
-            time += 1;
-            if (time <= 15)
+            // Nothing is being displayed, start a new one.
+            if (ALERT_DISPLAY.isFinished)
             {
-                this.alpha = (time / 15);
-            }
-            else if (time >= age - 14)
-            {
-                this.alpha = 1 + ((age - 14 - time) / 15);
+                ALERT_DISPLAY.setData(message, age, color);
+                ALERT_DISPLAY.x = Main.GAME_WIDTH - ALERT_DISPLAY.width - 5;
+                ALERT_DISPLAY.y = Main.GAME_HEIGHT - ALERT_DISPLAY.height - 5;
+                STAGE_REF.addChild(ALERT_DISPLAY);
+
+                if (!HAS_EVENT)
+                {
+                    STAGE_REF.addEventListener(Event.ENTER_FRAME, alertOnFrame, false, int.MAX_VALUE - 2);
+                    HAS_EVENT = true;
+                }
             }
             else
             {
-                this.alpha = 1;
+                ALERT_QUEUE.push(new AlertQueueItem(message, age, color));
             }
+        }
+
+        private static function alertOnFrame(e:Event):void
+        {
+            // Progress Active Alert
+            if (!ALERT_DISPLAY.isFinished)
+            {
+                ALERT_DISPLAY.progress();
+                if (ALERT_DISPLAY.time > ALERT_DISPLAY.age)
+                {
+                    ALERT_DISPLAY.isFinished = true;
+                    STAGE_REF.removeChild(ALERT_DISPLAY);
+
+                    if (ALERT_QUEUE.length == 0)
+                    {
+                        STAGE_REF.removeEventListener(Event.ENTER_FRAME, alertOnFrame);
+                        HAS_EVENT = false;
+                    }
+                }
+            }
+
+            // Add new alert if the old alert is finished
+            else if (ALERT_QUEUE.length > 0)
+            {
+                var newAlert:AlertQueueItem = ALERT_QUEUE.pop();
+                add(newAlert.message, newAlert.age, newAlert.color);
+            }
+        }
+    }
+}
+
+internal class AlertQueueItem
+{
+    public var message:String;
+    public var age:int;
+    public var color:uint;
+
+    public function AlertQueueItem(message:String, age:int = 120, color:uint = 0x000000)
+    {
+        this.message = message;
+        this.age = age;
+        this.color = color;
+    }
+}
+
+import flash.display.Sprite;
+import flash.text.AntiAliasType;
+import flash.text.TextField;
+import flash.text.TextFieldAutoSize;
+
+internal class AlertDisplay extends Sprite
+{
+    public var message:String;
+    public var age:int = 120;
+    public var time:int = 0;
+    public var isFinished:Boolean = true;
+
+    private var _textfield:TextField;
+
+    public function AlertDisplay()
+    {
+        this.mouseEnabled = false;
+        this.mouseChildren = false;
+
+        this.message = message;
+
+        _textfield = new TextField();
+        _textfield.x = 6;
+        _textfield.y = 2;
+        _textfield.selectable = false;
+        _textfield.embedFonts = true;
+        _textfield.antiAliasType = AntiAliasType.ADVANCED;
+        _textfield.autoSize = TextFieldAutoSize.LEFT;
+        _textfield.defaultTextFormat = Constant.TEXT_FORMAT;
+
+        this.addChild(_textfield);
+    }
+
+    public function setData(message:String, age:int = 120, color:uint = 0x000000):void
+    {
+        _textfield.htmlText = message;
+
+        this.graphics.clear()
+        this.graphics.lineStyle(1, 0xFFFFFF, 2, true);
+        this.graphics.beginFill(color, 0.75);
+        this.graphics.drawRect(0, 0, _textfield.width + 13, _textfield.height + 5);
+        this.graphics.endFill();
+
+        this.age = age;
+        this.time = 0;
+        this.alpha = 0;
+
+        this.isFinished = false;
+    }
+
+    public function progress():void
+    {
+        time += 1;
+        if (time <= 15)
+        {
+            this.alpha = (time / 15);
+        }
+        else if (time >= age - 14)
+        {
+            this.alpha = 1 + ((age - 14 - time) / 15);
+        }
+        else
+        {
+            this.alpha = 1;
         }
     }
 }

--- a/src/classes/Playlist.as
+++ b/src/classes/Playlist.as
@@ -362,7 +362,7 @@ package classes
                 case GlobalVariables.LOAD_ERROR:
                     ArcGlobals.instance.configLegacy = null;
                     load();
-                    _gvars.gameMain.addAlert("Error loading playlist");
+                    Alert.add("Error loading playlist");
                     break;
                 case GlobalVariables.LOAD_COMPLETE:
                     if (_gvars.gameMain.activePanel is MainMenu)

--- a/src/classes/chart/parse/ChartFFRLegacy.as
+++ b/src/classes/chart/parse/ChartFFRLegacy.as
@@ -2,19 +2,20 @@ package classes.chart.parse
 {
     import arc.ArcGlobals;
     import by.blooddy.crypto.MD5;
+    import classes.Alert;
+    import classes.Site;
+    import classes.SongInfo;
     import classes.chart.Note;
     import classes.chart.NoteChart;
-    import classes.Site;
+    import com.flashfla.media.Beatbox;
     import com.flashfla.utils.StringUtil;
     import com.flashfla.utils.sprintf;
-    import flash.utils.ByteArray;
-    import flash.net.URLRequest;
-    import flash.net.URLLoader;
     import flash.events.Event;
     import flash.events.IOErrorEvent;
     import flash.events.SecurityErrorEvent;
-    import com.flashfla.media.Beatbox;
-    import classes.SongInfo;
+    import flash.net.URLLoader;
+    import flash.net.URLRequest;
+    import flash.utils.ByteArray;
 
     public class ChartFFRLegacy extends NoteChart
     {
@@ -68,7 +69,7 @@ package classes.chart.parse
         {
             if (!validURL(url))
             {
-                GlobalVariables.instance.gameMain.addAlert("Incorrect legacy URL");
+                Alert.add("Incorrect legacy URL");
                 return;
             }
 
@@ -82,7 +83,7 @@ package classes.chart.parse
                     var xml:XML = new XML(event.target.data);
                     if (xml.localName() != "arc_engines")
                     {
-                        GlobalVariables.instance.gameMain.addAlert("Incorrect legacy URL");
+                        Alert.add("Incorrect legacy URL");
                         return;
                     }
                     for each (var node:XML in xml.children())
@@ -137,7 +138,7 @@ package classes.chart.parse
 
         private static function parseEngineError(event:Event = null):void
         {
-            GlobalVariables.instance.gameMain.addAlert("Error loading legacy engine");
+            Alert.add("Error loading legacy engine");
         }
 
         public static function parsePlaylist(data:Object, engine:Object = null):Array

--- a/src/classes/filter/SavedFilterButton.as
+++ b/src/classes/filter/SavedFilterButton.as
@@ -127,11 +127,11 @@ package classes.filter
             var success:Boolean = SystemUtil.setClipboard(filterString);
             if (success)
             {
-                _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
+                Alert.add(_lang.string("clipboard_success"), 120, Alert.GREEN);
             }
             else
             {
-                _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
+                Alert.add(_lang.string("clipboard_failure"), 120, Alert.RED);
             }
         }
     }

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -902,7 +902,7 @@ package game
 
             if (!canSendScore(gameResult, true, true, false, false))
             {
-                _gvars.gameMain.addAlert(_lang.string("game_result_error_enabled_mods"), 90, Alert.RED);
+                Alert.add(_lang.string("game_result_error_enabled_mods"), 90, Alert.RED);
                 return;
             }
 
@@ -963,12 +963,12 @@ package game
 
             if (data.result == 0)
             {
-                _gvars.gameMain.addAlert(_lang.string("game_result_save_success"), 90, Alert.DARK_GREEN);
+                Alert.add(_lang.string("game_result_save_success"), 90, Alert.DARK_GREEN);
 
                 // Server Message
                 if (data.gServerMessage != null)
                 {
-                    _gvars.gameMain.addAlert(data.gServerMessage, 360);
+                    Alert.add(data.gServerMessage, 360);
                 }
 
                 // Server Message Popup
@@ -998,7 +998,7 @@ package game
                     // Check Old vs New Rankings.
                     if (data.new_ranking < data.old_ranking && data.old_ranking > 0)
                     {
-                        _gvars.gameMain.addAlert("New Best Rank: " + data.old_ranking + "->" + data.new_ranking + " (" + ((data.old_ranking - data.new_ranking) * -1) + ")", 240, Alert.DARK_GREEN);
+                        Alert.add("New Best Rank: " + data.old_ranking + "->" + data.new_ranking + " (" + ((data.old_ranking - data.new_ranking) * -1) + ")", 240, Alert.DARK_GREEN);
                     }
 
                     // Check raw score vs level ranks and update.
@@ -1069,7 +1069,7 @@ package game
             else
             {
                 if (!data.ignore)
-                    _gvars.gameMain.addAlert("Failed to save results. (ERR: " + data.result + ")", 360, Alert.RED);
+                    Alert.add("Failed to save results. (ERR: " + data.result + ")", 360, Alert.RED);
 
                 if (resultsDisplay != null)
                     resultsDisplay.result_rank.htmlText = data.ignore ? "" : "Score save failed!";
@@ -1082,7 +1082,7 @@ package game
         private function siteLoadError(e:Event = null):void
         {
             removeLoaderListeners(siteLoadComplete, siteLoadError);
-            _gvars.gameMain.addAlert(_lang.string("error_server_connection_failure"), 120, Alert.RED);
+            Alert.add(_lang.string("error_server_connection_failure"), 120, Alert.RED);
 
             if (resultsDisplay != null)
                 resultsDisplay.result_rank.htmlText = "Score save failed!";
@@ -1191,12 +1191,12 @@ package game
                 {
                     if (data.result == 0)
                     {
-                        //_gvars.gameMain.addAlert("Score Saved successfully!", 90);
+                        //Alert.add("Score Saved successfully!", 90);
 
                         // Server Message
                         if (data.gServerMessage != null)
                         {
-                            _gvars.gameMain.addAlert(data.gServerMessage, 360);
+                            Alert.add(data.gServerMessage, 360);
                         }
 
                         // Server Message Popup
@@ -1272,7 +1272,7 @@ package game
             // Display F2 Shortcut key only once per session.
             if (!Flags.VALUES[Flags.F2_REPLAYS])
             {
-                _gvars.gameMain.addAlert("Replay saved to History. (Press F2)", 150);
+                Alert.add("Replay saved to History. (Press F2)", 150);
                 Flags.VALUES[Flags.F2_REPLAYS] = true;
             }
 
@@ -1358,7 +1358,7 @@ package game
 
             var data:Object = JSON.parse(e.target.data);
 
-            _gvars.gameMain.addAlert(_lang.string("replay_save_status_" + data.result), 90, (data.result == 0 ? Alert.GREEN : Alert.RED));
+            Alert.add(_lang.string("replay_save_status_" + data.result), 90, (data.result == 0 ? Alert.GREEN : Alert.RED));
         }
 
         /**
@@ -1367,7 +1367,7 @@ package game
         private function replayLoadError(e:Event = null):void
         {
             removeLoaderListeners(replayLoadComplete, replayLoadError);
-            _gvars.gameMain.addAlert(_lang.string("error_server_connection_failure"), 120, Alert.RED);
+            Alert.add(_lang.string("error_server_connection_failure"), 120, Alert.RED);
         }
 
     }

--- a/src/game/GameplayDisplay.as
+++ b/src/game/GameplayDisplay.as
@@ -200,7 +200,7 @@ package game
             song = options.song;
             if (!options.isEditor && song.chart.Notes.length == 0)
             {
-                _gvars.gameMain.addAlert("Chart has no notes, returning to main menu...", 120, Alert.RED);
+                Alert.add("Chart has no notes, returning to main menu...", 120, Alert.RED);
                 var screen:int = _gvars.activeUser.startUpScreen;
                 if (!_gvars.activeUser.isGuest && (screen == 0 || screen == 1) && !MultiplayerSingleton.getInstance().connection.connected)
                 {
@@ -367,15 +367,15 @@ package game
             {
                 options.isAutoplay = true;
                 stage.frameRate = options.frameRate;
-                stage.addEventListener(Event.ENTER_FRAME, editorOnEnterFrame, false, int.MAX_VALUE, true);
-                stage.addEventListener(KeyboardEvent.KEY_DOWN, editorKeyboardKeyDown, false, int.MAX_VALUE, true);
+                stage.addEventListener(Event.ENTER_FRAME, editorOnEnterFrame, false, int.MAX_VALUE - 10, true);
+                stage.addEventListener(KeyboardEvent.KEY_DOWN, editorKeyboardKeyDown, false, int.MAX_VALUE - 10, true);
             }
             else
             {
                 stage.frameRate = song.frameRate;
-                stage.addEventListener(Event.ENTER_FRAME, onEnterFrame, false, int.MAX_VALUE, true);
-                stage.addEventListener(KeyboardEvent.KEY_DOWN, keyboardKeyDown, true, int.MAX_VALUE, true);
-                stage.addEventListener(KeyboardEvent.KEY_UP, keyboardKeyUp, true, int.MAX_VALUE, true);
+                stage.addEventListener(Event.ENTER_FRAME, onEnterFrame, false, int.MAX_VALUE - 10, true);
+                stage.addEventListener(KeyboardEvent.KEY_DOWN, keyboardKeyDown, true, int.MAX_VALUE - 10, true);
+                stage.addEventListener(KeyboardEvent.KEY_UP, keyboardKeyUp, true, int.MAX_VALUE - 10, true);
             }
         }
 
@@ -721,7 +721,7 @@ package game
         private function siteLoadError(e:Event = null):void
         {
             removeLoaderListeners();
-            //_gvars.gameMain.addAlert("Error sending game start, score may not save", 60, Alert.RED);
+            //Alert.add("Error sending game start, score may not save", 60, Alert.RED);
         }
 
         /*#########################################################################################*\
@@ -1128,7 +1128,7 @@ package game
             else if (keyCode == Keyboard.F8 && (CONFIG::debug || _gvars.playerUser.isDeveloper || _gvars.playerUser.isAdmin))
             {
                 options.isAutoplay = !options.isAutoplay;
-                _gvars.gameMain.addAlert("Bot Play: " + options.isAutoplay, 60);
+                Alert.add("Bot Play: " + options.isAutoplay, 60);
             }
 
             e.stopImmediatePropagation();
@@ -2249,7 +2249,7 @@ package game
             if (gameplay.status == Multiplayer.STATUS_RESULTS && !multiplayerResults[user.id])
             {
                 multiplayerResults[user.id] = true;
-                _gvars.gameMain.addAlert(user.name + " finished playing the song", 240, Alert.RED);
+                Alert.add(user.name + " finished playing the song", 240, Alert.RED);
             }
         }
 

--- a/src/menu/MainMenu.as
+++ b/src/menu/MainMenu.as
@@ -486,7 +486,7 @@ package menu
 
             function c_rankFail(e:*):void
             {
-                _gvars.gameMain.addAlert(_lang.string("skill_rank_update_fail"), 90, Alert.RED);
+                Alert.add(_lang.string("skill_rank_update_fail"), 90, Alert.RED);
                 if (_gvars.gameMain.activePanel is MainMenu)
                 {
                     rankUpdateThrobber.stop();

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -19,6 +19,7 @@ package menu
     import classes.Alert;
     import classes.Language;
     import classes.Playlist;
+    import classes.SongInfo;
     import classes.SongPlayerBytes;
     import classes.SongPreview;
     import classes.SongQueueItem;
@@ -53,7 +54,6 @@ package menu
     import popups.PopupFilterManager;
     import popups.PopupQueueManager;
     import popups.PopupSongNotes;
-    import classes.SongInfo;
 
     public class MenuSongSelection extends MenuPanel
     {
@@ -869,7 +869,7 @@ package menu
                 }
                 else
                 {
-                    _gvars.gameMain.addAlert(sprintf(_lang.string("song_selection_load_music_for"), {"name": songInfo.name}), 90);
+                    Alert.add(sprintf(_lang.string("song_selection_load_music_for"), {"name": songInfo.name}), 90);
                     song.addEventListener(Event.COMPLETE, e_menuMusicConvertSongLoad);
                 }
             }
@@ -896,7 +896,7 @@ package menu
                 _gvars.songQueue.push(Playlist.instance.getSongInfo(_gvars.options.replay.level));
 
                 // Switch to game
-                _gvars.gameMain.addAlert(_lang.string("song_selection_load_play_chart_preview"));
+                Alert.add(_lang.string("song_selection_load_play_chart_preview"));
                 switchTo(Main.GAME_PLAY_PANEL);
             }
         }
@@ -922,7 +922,7 @@ package menu
                 }
                 else
                 {
-                    _gvars.gameMain.addAlert(sprintf(_lang.string("song_selection_load_music_for"), {"name": songInfo.name}), 90);
+                    Alert.add(sprintf(_lang.string("song_selection_load_music_for"), {"name": songInfo.name}), 90);
                     song.addEventListener(Event.COMPLETE, e_songPreviewConvertSongLoad);
                 }
             }
@@ -1354,7 +1354,7 @@ package menu
          */
         private function songQueueClick(e:Event):void
         {
-            _gvars.gameMain.addAlert(sprintf(_lang.string("song_selection_add_to_queue"), {song_name: _playlist.getSongInfo(e.target.level).name}), 90);
+            Alert.add(sprintf(_lang.string("song_selection_add_to_queue"), {song_name: _playlist.getSongInfo(e.target.level).name}), 90);
             _gvars.songQueue.push(_playlist.getSongInfo(e.target.level));
             saveQueuePlaylist();
             if (options.activeGenre == PLAYLIST_QUEUE)
@@ -1801,7 +1801,7 @@ package menu
                     }
                     else
                     {
-                        _gvars.gameMain.addAlert(_lang.string("song_selection_no_songs_random"), 120, Alert.RED);
+                        Alert.add(_lang.string("song_selection_no_songs_random"), 120, Alert.RED);
                     }
                 }
             }
@@ -1975,7 +1975,7 @@ package menu
             {
                 var songDetails:Object = _playlist.getSongInfo(level_id);
                 if (songDetails != null && songDetails.error == null)
-                    _gvars.gameMain.addAlert(sprintf(_lang.string("song_purchase_complete"), {"name": songDetails.name}), 120, Alert.DARK_GREEN);
+                    Alert.add(sprintf(_lang.string("song_purchase_complete"), {"name": songDetails.name}), 120, Alert.DARK_GREEN);
 
                 _gvars.activeUser.setPurchasedString(response["purchased"]);
                 _gvars.activeUser.credits = response["credits"];
@@ -1985,7 +1985,7 @@ package menu
             }
             else
             {
-                _gvars.gameMain.addAlert(_lang.string("song_purchase_error_" + response["status"]), 120, Alert.RED);
+                Alert.add(_lang.string("song_purchase_error_" + response["status"]), 120, Alert.RED);
             }
 
             if (options.activeSongId == level_id && options.infoTab == TAB_PLAYLIST)
@@ -2048,7 +2048,7 @@ package menu
          */
         private function playMenuMusicSong(song:Song):void
         {
-            _gvars.gameMain.addAlert(_lang.string("song_selection_playing_menu_music"));
+            Alert.add(_lang.string("song_selection_playing_menu_music"));
 
             LocalStore.setVariable("menu_music", song.songInfo.name);
             var par:MainMenu = ((this.my_Parent) as MainMenu);
@@ -2071,7 +2071,7 @@ package menu
          */
         private function playSongPreview(song:Song):void
         {
-            _gvars.gameMain.addAlert(_lang.string("song_selection_playing_song_preview"));
+            Alert.add(_lang.string("song_selection_playing_song_preview"));
 
             if (_gvars.menuMusic)
                 _gvars.menuMusic.stop();
@@ -2096,7 +2096,9 @@ package menu
 
 
 import assets.GameBackgroundColor;
+
 import classes.ui.Text;
+
 import flash.display.DisplayObjectContainer;
 import flash.display.Sprite;
 import flash.events.Event;

--- a/src/popups/PopupOptions.as
+++ b/src/popups/PopupOptions.as
@@ -8,6 +8,8 @@ package popups
     import classes.Noteskins;
     import classes.NoteskinsStruct;
     import classes.Playlist;
+    import classes.Room;
+    import classes.SongInfo;
     import classes.User;
     import classes.chart.Song;
     import classes.chart.parse.ChartFFRLegacy;
@@ -54,8 +56,6 @@ package popups
     import menu.MainMenu;
     import menu.MenuPanel;
     import menu.MenuSongSelection;
-    import classes.Room;
-    import classes.SongInfo;
 
     public class PopupOptions extends MenuPanel
     {
@@ -210,11 +210,11 @@ package popups
             var success:Boolean = SystemUtil.setClipboard(optionsString);
             if (success)
             {
-                _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
+                Alert.add(_lang.string("clipboard_success"), 120, Alert.GREEN);
             }
             else
             {
-                _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
+                Alert.add(_lang.string("clipboard_failure"), 120, Alert.RED);
             }
         }
 
@@ -229,12 +229,12 @@ package popups
             {
                 var item:Object = JSON.parse(optionsJSON);
                 _gvars.activeUser.settings = item;
-                _gvars.gameMain.addAlert("Settings Imported!", 120, Alert.GREEN);
+                Alert.add("Settings Imported!", 120, Alert.GREEN);
                 renderOptions();
             }
             catch (e:Error)
             {
-                _gvars.gameMain.addAlert("Import Fail...", 120, Alert.GREEN);
+                Alert.add("Import Fail...", 120, Alert.GREEN);
             }
         }
 
@@ -1293,9 +1293,9 @@ package popups
             {
                 var success:Boolean = SystemUtil.setClipboard(noteskinsString());
                 if (success)
-                    GlobalVariables.instance.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
+                    Alert.add(_lang.string("clipboard_success"), 120, Alert.GREEN);
                 else
-                    GlobalVariables.instance.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
+                    Alert.add(_lang.string("clipboard_failure"), 120, Alert.RED);
                 return;
             }
 
@@ -1476,7 +1476,7 @@ package popups
                     _gvars.air_useVSync = !_gvars.air_useVSync;
                     LocalStore.setVariable("air_useVSync", _gvars.air_useVSync);
                     stage.vsyncEnabled = _gvars.air_useVSync;
-                    _gvars.gameMain.addAlert("Set VSYNC: " + stage.vsyncEnabled, 120, Alert.RED);
+                    Alert.add("Set VSYNC: " + stage.vsyncEnabled, 120, Alert.RED);
                 }
             }
 
@@ -1499,7 +1499,7 @@ package popups
                     }
                     else
                     {
-                        _gvars.gameMain.addAlert(_lang.string("air_options_unable_to_start_websockets"), 120, Alert.RED);
+                        Alert.add(_lang.string("air_options_unable_to_start_websockets"), 120, Alert.RED);
                     }
                 }
             }
@@ -1611,7 +1611,7 @@ package popups
 
         private function engineAdd(engine:Object):void
         {
-            _gvars.gameMain.addAlert("Engine Loaded: " + engine.name, 80);
+            Alert.add("Engine Loaded: " + engine.name, 80);
             for (var i:int = 0; i < _avars.legacyEngines.length; i++)
             {
                 if (_avars.legacyEngines[i].id == engine.id)
@@ -1645,7 +1645,7 @@ package popups
                     continue;
                 if (engine["config_url"] == null)
                 {
-                    _gvars.gameMain.addAlert("Please re-add " + engine["name"] + ", missing required information.", 240, Alert.RED);
+                    Alert.add("Please re-add " + engine["name"] + ", missing required information.", 240, Alert.RED);
                     continue;
                 }
                 engineCombo.addItem(item);
@@ -1676,7 +1676,7 @@ package popups
                 }
                 LocalStore.setVariable("custom_noteskin", noteskinsString(), 20971520); // 20MB Mins size requested.
                 Noteskins.instance.loadCustomNoteskin();
-                GlobalVariables.instance.gameMain.addAlert(_lang.string("popup_noteskin_saved"), 90, Alert.GREEN);
+                Alert.add(_lang.string("popup_noteskin_saved"), 90, Alert.GREEN);
             }
             catch (e:Error)
             {
@@ -1905,9 +1905,9 @@ package popups
             }
             _avars.configJudge = judge;
             if (judge)
-                _gvars.gameMain.addAlert("Judge window set, score saving disabled");
+                Alert.add("Judge window set, score saving disabled");
             else
-                _gvars.gameMain.addAlert("Judge window cleared");
+                Alert.add("Judge window cleared");
         }
 
         private function arcJudgeMenu():ContextMenu

--- a/src/popups/PopupQueueManager.as
+++ b/src/popups/PopupQueueManager.as
@@ -355,11 +355,11 @@ internal class QueueBox extends Sprite
         var success:Boolean = SystemUtil.setClipboard(queueString);
         if (success)
         {
-            _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
+            Alert.add(_lang.string("clipboard_success"), 120, Alert.GREEN);
         }
         else
         {
-            _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
+            Alert.add(_lang.string("clipboard_failure"), 120, Alert.RED);
         }
     }
 

--- a/src/popups/PopupReplayHistory.as
+++ b/src/popups/PopupReplayHistory.as
@@ -2,9 +2,11 @@ package popups
 {
     import arc.ArcGlobals;
     import assets.GameBackgroundColor;
+    import classes.Alert;
     import classes.FileTracker;
     import classes.Language;
     import classes.Playlist;
+    import classes.SongInfo;
     import classes.replay.Replay;
     import classes.ui.Box;
     import classes.ui.BoxButton;
@@ -24,7 +26,6 @@ package popups
     import flash.geom.Point;
     import flash.utils.getTimer;
     import menu.MenuPanel;
-    import classes.SongInfo;
 
     public class PopupReplayHistory extends MenuPanel
     {
@@ -331,7 +332,7 @@ package popups
             var r:Replay = new Replay(new Date().getTime());
             r.parseEncode(replayString);
             if (r.isEdited)
-                _gvars.gameMain.addAlert(_lang.string("popup_replay_import_edited"), 180);
+                Alert.add(_lang.string("popup_replay_import_edited"), 180);
             if (r.isValid())
             {
                 _gvars.replayHistory.unshift(r);
@@ -346,7 +347,7 @@ package popups
                 renderReplays();
             }
             else
-                _gvars.gameMain.addAlert(_lang.string("popup_replay_import_invalid"));
+                Alert.add(_lang.string("popup_replay_import_invalid"));
         }
 
         private function e_boxClickHandler(e:MouseEvent):void
@@ -570,6 +571,7 @@ package popups
 
 import classes.Alert;
 import classes.Language;
+import classes.SongInfo;
 import classes.replay.Replay;
 import classes.ui.Box;
 import classes.ui.BoxButton;
@@ -581,7 +583,6 @@ import flash.display.Sprite;
 import flash.events.MouseEvent;
 import game.GameOptions;
 import popups.PopupReplayHistory;
-import classes.SongInfo;
 
 internal class ReplayBox extends Sprite
 {
@@ -655,11 +656,11 @@ internal class ReplayBox extends Sprite
         var success:Boolean = SystemUtil.setClipboard(replayString);
         if (success)
         {
-            _gvars.gameMain.addAlert(_lang.string("clipboard_success"), 120, Alert.GREEN);
+            Alert.add(_lang.string("clipboard_success"), 120, Alert.GREEN);
         }
         else
         {
-            _gvars.gameMain.addAlert(_lang.string("clipboard_failure"), 120, Alert.RED);
+            Alert.add(_lang.string("clipboard_failure"), 120, Alert.RED);
         }
     }
 
@@ -673,7 +674,7 @@ internal class ReplayBox extends Sprite
     {
         if (songInfo == null)
         {
-            _gvars.gameMain.addAlert(_lang.string("popup_replay_missing_song_data"));
+            Alert.add(_lang.string("popup_replay_missing_song_data"));
             return;
         }
         if (!replay.user.isLoaded())

--- a/src/popups/PopupSongNotes.as
+++ b/src/popups/PopupSongNotes.as
@@ -352,7 +352,7 @@ package popups
                 if (_data["result"] && _data["result"] == "success")
                 {
                     _gvars.playerUser.songRatings[songInfo["level"]] = sRating.value;
-                    //_gvars.gameMain.addAlert("Saved rating for " + sObject["name"] + "!", 120, Alert.GREEN);
+                    //Alert.add("Saved rating for " + sObject["name"] + "!", 120, Alert.GREEN);
                     if (_data["type"] && _data["type"] == 1)
                     {
                         _playlist.playList[songInfo["level"]]["song_rating"] = _data["new_value"];
@@ -360,7 +360,7 @@ package popups
                 }
                 else
                 {
-                    //_gvars.gameMain.addAlert("Failed to save song rating.", 120, Alert.RED);
+                    //Alert.add("Failed to save song rating.", 120, Alert.RED);
                 }
             }
             catch (e:Error)


### PR DESCRIPTION
- Use a single Alert Display instead of creating a new one each time.
- Make it into a static class so using a reference through GlobalVariables isn't needed.
- Only add/remove event listeners when needed instead of between every alert.

This should fix lag with Alerts during gameplay due to rapid creation/destruction of textfields, which has been mitigated.

Fixes issue #269.