### PR TITLE
Multiplayer Bug Fixes

### DIFF
--- a/src/arc/mp/MultiplayerPanel.as
+++ b/src/arc/mp/MultiplayerPanel.as
@@ -389,6 +389,8 @@ package arc.mp
         {
             if (buttonMP != null)
                 buttonMP.visible = show;
+            if (buttonDisconnect != null)
+                buttonDisconnect.visible = show;
             if (textLogin != null)
                 textLogin.visible = show;
             if (window != null)

--- a/src/classes/Room.as
+++ b/src/classes/Room.as
@@ -228,11 +228,8 @@ package classes
 
         public function isAllPlayersSameSong():Boolean
         {
-            if (_playerCount <= 0)
+            if (_playerCount <= 1)
                 return false;
-
-            if (_playerCount == 1)
-                return true;
 
             var songP1:SongInfo = getPlayer(1).gameplay.songInfo;
 

--- a/src/com/flashfla/net/Multiplayer.as
+++ b/src/com/flashfla/net/Multiplayer.as
@@ -350,6 +350,7 @@ package com.flashfla.net
 
                 // Update each player's gameplay
                 var anyUserStatusChanged:Boolean = false;
+                var anyPlayerStatusChanged:Boolean = false;
                 var anyUserSongNameChanged:Boolean = false;
                 for each (var user:User in roomPlayers)
                 {
@@ -359,14 +360,18 @@ package com.flashfla.net
                     updateUserGameplayFromRoom(room, user);
 
                     if (previousUserStatus != user.gameplay.status)
+                    {
                         anyUserStatusChanged = true;
+                        if(room.isPlayer(user))
+                            anyPlayerStatusChanged = true;
+                    }
 
                     if (previousSongName != (user.gameplay.songInfo ? user.gameplay.songInfo.name : ""))
                         eventUserUpdate(user);
                 }
 
                 // Process gameplay status changes for game start/end
-                if (room.isAllPlayersInStatus(STATUS_LOADED) && room.isAllPlayersSameSong())
+                if (currentUserIsPlayer && room.isAllPlayersInStatus(STATUS_LOADED) && room.isAllPlayersSameSong())
                 {
                     currentUser.gameplay.status = STATUS_PLAYING;
 
@@ -376,7 +381,7 @@ package com.flashfla.net
                     if (currentUserIsPlayer)
                         eventGameStart(room);
                 }
-                else if (currentUserIsPlayer && currentUser.gameplay.status == STATUS_RESULTS)
+                else if (currentUserIsPlayer && room.isAllPlayersInStatus(STATUS_RESULTS) && anyPlayerStatusChanged)
                 {
                     reportSongEnd(room);
                     eventGameResults(room);

--- a/src/com/flashfla/net/Multiplayer.as
+++ b/src/com/flashfla/net/Multiplayer.as
@@ -644,6 +644,7 @@ package com.flashfla.net
                 vars[prefix + "_UID"] = null;
                 vars[prefix + "_SONGID_PROGRESS"] = null;
                 vars[prefix + "_SONGID"] = null;
+                vars[prefix + "_STATE"] = null;
 
                 vars["arc_engine" + currentUser.id] = null;
                 vars["arc_replay" + currentUser.id] = null;

--- a/src/com/flashfla/net/Multiplayer.as
+++ b/src/com/flashfla/net/Multiplayer.as
@@ -366,25 +366,22 @@ package com.flashfla.net
                 }
 
                 // Process gameplay status changes for game start/end
-                if (anyUserStatusChanged)
+                if (room.isAllPlayersInStatus(STATUS_LOADED) && room.isAllPlayersSameSong())
                 {
-                    if (room.isAllPlayersInStatus(STATUS_LOADED) && room.isAllPlayersSameSong())
-                    {
-                        currentUser.gameplay.status = STATUS_PLAYING;
+                    currentUser.gameplay.status = STATUS_PLAYING;
 
-                        reportSongStart(room);
-                        sendCurrentUserStatus(room);
+                    reportSongStart(room);
+                    sendCurrentUserStatus(room);
 
-                        if (currentUserIsPlayer)
-                            eventGameStart(room);
-                    }
-                    else if (currentUserIsPlayer && currentUser.gameplay.status == STATUS_RESULTS)
-                    {
-                        reportSongEnd(room);
-                        eventGameResults(room);
+                    if (currentUserIsPlayer)
+                        eventGameStart(room);
+                }
+                else if (currentUserIsPlayer && currentUser.gameplay.status == STATUS_RESULTS)
+                {
+                    reportSongEnd(room);
+                    eventGameResults(room);
 
-                        eventUserUpdate(currentUser);
-                    }
+                    eventUserUpdate(currentUser);
                 }
             }
 


### PR DESCRIPTION
Fixes various bugs regarding multiplayer. This doesn't cover spectating or the MP editor.
Fixed bugs where:
- Results would display several times
- Song would not start upon loading
- MP Disconnect/Connect button being drawn on top of the results screen
- Status would not reset when leaving a room
