### PR TITLE
Add Copy Screenshot to Clipboard on CTRL + Screenshot button

### DIFF
--- a/asconfig.release.json
+++ b/asconfig.release.json
@@ -16,7 +16,7 @@
             },
             {
                 "name": "CONFIG::timeStamp",
-                "value": "\"2022-01-28\""
+                "value": "\"2022-02-08\""
             },
             {
                 "name": "R3::HASH_STRING",

--- a/asconfig.release.json
+++ b/asconfig.release.json
@@ -16,7 +16,7 @@
             },
             {
                 "name": "CONFIG::timeStamp",
-                "value": "\"2022-02-08\""
+                "value": "\"2022-01-28\""
             },
             {
                 "name": "R3::HASH_STRING",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+R^3 (Unreleased) [2022-xx-xx]
+---------------------------------------------------------------------
+- Add ability to take and save a screenshot directly to the clipboard. @Zageron
+- Assure that no tool-tips appear in any screenshots. @Zageron
+
 R^3 (v1.4.3) [2022-01-28]
 ---------------------------------------------------------------------
 @Psycast

--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -577,6 +577,14 @@ package
             Screenshots.takeScreenshot(gameMain, filename);
         }
 
+        /**
+         * Takes a screenshot of the stage and saves it to clipboard.
+         */
+        public function copyScreenshot():void
+        {
+            Screenshots.copyScreenshot(gameMain);
+        }
+
         public function logDebugError(id:String, params:Object = null):void
         {
             var output:String = id;

--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -580,9 +580,9 @@ package
         /**
          * Takes a screenshot of the stage and saves it to clipboard.
          */
-        public function copyScreenshot():void
+        public function saveToClipboard():void
         {
-            Screenshots.copyScreenshot(gameMain);
+            Screenshots.saveToClipboard(gameMain);
         }
 
         public function logDebugError(id:String, params:Object = null):void

--- a/src/GlobalVariables.as
+++ b/src/GlobalVariables.as
@@ -580,7 +580,7 @@ package
         /**
          * Takes a screenshot of the stage and saves it to clipboard.
          */
-        public function saveToClipboard():void
+        public function saveScreenshotToClipboard():void
         {
             Screenshots.saveToClipboard(gameMain);
         }

--- a/src/classes/ui/BoxIcon.as
+++ b/src/classes/ui/BoxIcon.as
@@ -247,7 +247,7 @@ package classes.ui
         /**
          * Remove the hover sprite from the box icon immediately.
          */
-        public function purge_hover_sprite():void
+        public function purgeHoverSprite():void
         {
             if (_hoverSprite && _hoverSprite.parent)
             {

--- a/src/classes/ui/BoxIcon.as
+++ b/src/classes/ui/BoxIcon.as
@@ -243,5 +243,16 @@ package classes.ui
         {
             return _enabled;
         }
+
+        /**
+         * Remove the hover sprite from the box icon immediately.
+         */
+        public function purge_hover_sprite():void
+        {
+            if (_hoverSprite && _hoverSprite.parent)
+            {
+                _hoverSprite.parent.removeChild(_hoverSprite);
+            }
+        }
     }
 }

--- a/src/com/flashfla/utils/Screenshots.as
+++ b/src/com/flashfla/utils/Screenshots.as
@@ -15,6 +15,11 @@ package com.flashfla.utils
 
     public class Screenshots
     {
+        /**
+         * Capture the bitmap of the stage.
+         * @param gameMain Reference to the main sprite.
+         * @return Bitmap data representation of the entire stage.
+         */
         private static function captureStage(gameMain:Main):BitmapData
         {
             // Create Bitmap of Stage
@@ -23,9 +28,10 @@ package com.flashfla.utils
             return b;
         }
 
-        //- ScreenShot Handling
         /**
          * Takes a screenshot of the stage and saves it to disk.
+         * @param gameMain
+         * @param filename
          */
         public static function takeScreenshot(gameMain:Main, filename:String = null):void
         {
@@ -44,8 +50,9 @@ package com.flashfla.utils
 
         /**
          * Takes a screenshot of the stage and saves it to clipboard.
+         * @param gameMain
          */
-        public static function copyScreenshot(gameMain:Main):void
+        public static function saveToClipboard(gameMain:Main):void
         {
             var b:BitmapData = captureStage(gameMain);
             Clipboard.generalClipboard.clear();

--- a/src/com/flashfla/utils/Screenshots.as
+++ b/src/com/flashfla/utils/Screenshots.as
@@ -5,6 +5,8 @@
 package com.flashfla.utils
 {
     import classes.Language;
+    import flash.desktop.Clipboard;
+    import flash.desktop.ClipboardFormats;
     import flash.display.BitmapData;
     import flash.net.FileReference;
     import by.blooddy.crypto.image.PNGEncoder;
@@ -13,15 +15,21 @@ package com.flashfla.utils
 
     public class Screenshots
     {
+        private static function captureStage(gameMain:Main):BitmapData
+        {
+            // Create Bitmap of Stage
+            var b:BitmapData = new BitmapData(Main.GAME_WIDTH, Main.GAME_HEIGHT, false, 0x000000);
+            b.draw(gameMain.stage);
+            return b;
+        }
+
         //- ScreenShot Handling
         /**
          * Takes a screenshot of the stage and saves it to disk.
          */
         public static function takeScreenshot(gameMain:Main, filename:String = null):void
         {
-            // Create Bitmap of Stage
-            var b:BitmapData = new BitmapData(Main.GAME_WIDTH, Main.GAME_HEIGHT, false, 0x000000);
-            b.draw(gameMain.stage);
+            var b:BitmapData = captureStage(gameMain);
 
             try
             {
@@ -32,6 +40,17 @@ package com.flashfla.utils
             {
                 Alert.add(Language.instance.string("save_image_error"), 120);
             }
+        }
+
+        /**
+         * Takes a screenshot of the stage and saves it to clipboard.
+         */
+        public static function copyScreenshot(gameMain:Main):void
+        {
+            var b:BitmapData = captureStage(gameMain);
+            Clipboard.generalClipboard.clear();
+            Clipboard.generalClipboard.setData(ClipboardFormats.BITMAP_FORMAT, b, false);
+            Alert.add(Language.instance.string("copy_image_to_clipboard"), 120, Alert.GREEN);
         }
     }
 }

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -213,7 +213,7 @@ package game
             // Song Results Buttons
             navScreenShot = new BoxIcon(this, 522, 6, 32, 32, new iconPhoto(), eventHandler);
             navScreenShot.setIconColor("#E2FEFF");
-            navScreenShot.setHoverText(_lang.string("game_results_queue_save_screenshot"), "bottom");
+            navScreenShot.setHoverText(_lang.string("game_results_queue_save_screenshot_clipboard_hint"), "bottom");
 
             navSaveReplay = new BoxIcon(this, 485, 6, 32, 32, new iconVideo(), eventHandler);
             navSaveReplay.setIconColor("#E2FEFF");
@@ -717,9 +717,9 @@ package game
 
             else if (target == navScreenShot)
             {
+                navScreenShot.purge_hover_sprite();
                 if (e.ctrlKey)
                 {
-                    navScreenShot.purge_hover_sprite();
                     _gvars.saveScreenshotToClipboard()
                 }
                 else
@@ -729,7 +729,6 @@ package game
                     {
                         ext = songResults[resultIndex].screenshot_path;
                     }
-                    navScreenShot.purge_hover_sprite();
                     _gvars.takeScreenShot(ext);
                 }
 

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -717,7 +717,7 @@ package game
 
             else if (target == navScreenShot)
             {
-                navScreenShot.purge_hover_sprite();
+                navScreenShot.purgeHoverSprite();
                 if (e.ctrlKey)
                 {
                     _gvars.saveScreenshotToClipboard()

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -703,6 +703,10 @@ package game
                     target = navMenu;
                     stage.removeEventListener(KeyboardEvent.KEY_DOWN, eventHandler);
                 }
+                else if (keyCode == Keyboard.C && e.controlKey)
+                {
+                    _gvars.copyScreenshot();
+                }
             }
 
             if (!target)

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -134,7 +134,6 @@ package game
         {
             // Add keyboard navigation
             stage.addEventListener(KeyboardEvent.KEY_DOWN, eventHandler);
-            stage.addEventListener(KeyboardEvent.KEY_UP, eventHandler);
 
             // Add Mouse Move for graphs
             stage.addEventListener(MouseEvent.MOUSE_MOVE, e_graphHover);
@@ -214,7 +213,7 @@ package game
             // Song Results Buttons
             navScreenShot = new BoxIcon(this, 522, 6, 32, 32, new iconPhoto(), eventHandler);
             navScreenShot.setIconColor("#E2FEFF");
-            setContextualTakeScreenshotHovertext(false);
+            navScreenShot.setHoverText(_lang.string("game_results_queue_save_screenshot"), "bottom");
 
             navSaveReplay = new BoxIcon(this, 485, 6, 32, 32, new iconVideo(), eventHandler);
             navSaveReplay.setIconColor("#E2FEFF");
@@ -263,7 +262,6 @@ package game
         {
             // Remove keyboard navigation
             stage.removeEventListener(KeyboardEvent.KEY_DOWN, eventHandler);
-            stage.removeEventListener(KeyboardEvent.KEY_UP, eventHandler);
 
             // Remove Mouse Move for graphs
             stage.removeEventListener(MouseEvent.MOUSE_MOVE, e_graphHover);
@@ -705,20 +703,6 @@ package game
                     target = navMenu;
                     stage.removeEventListener(KeyboardEvent.KEY_DOWN, eventHandler);
                 }
-                else if (e.ctrlKey)
-                {
-                    setContextualTakeScreenshotHovertext(true);
-                }
-            }
-
-            if (e.type == "keyUp" && !_mp.gameplayPlayingStatusResults())
-            {
-                if (!e.ctrlKey)
-                {
-                    setContextualTakeScreenshotHovertext(false);
-                }
-
-                return;
             }
 
 
@@ -735,6 +719,7 @@ package game
             {
                 if (e.ctrlKey)
                 {
+                    navScreenShot.purge_hover_sprite();
                     _gvars.saveToClipboard()
                 }
                 else
@@ -744,6 +729,7 @@ package game
                     {
                         ext = songResults[resultIndex].screenshot_path;
                     }
+                    navScreenShot.purge_hover_sprite();
                     _gvars.takeScreenShot(ext);
                 }
 
@@ -1439,23 +1425,6 @@ package game
         {
             removeLoaderListeners(replayLoadComplete, replayLoadError);
             Alert.add(_lang.string("error_server_connection_failure"), 120, Alert.RED);
-        }
-
-
-        /**
-         * Set the hover text for the screenshot button based on conext.
-         * @param isClipboardMode Whether to use the clipboard tooltip or not.
-         */
-        private function setContextualTakeScreenshotHovertext(isClipboardMode:Boolean):void
-        {
-            if (isClipboardMode)
-            {
-                navScreenShot.setHoverText(null);
-            }
-            else
-            {
-                navScreenShot.setHoverText(_lang.string("game_results_queue_save_screenshot"), "bottom");
-            }
         }
 
     }

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -720,7 +720,7 @@ package game
                 if (e.ctrlKey)
                 {
                     navScreenShot.purge_hover_sprite();
-                    _gvars.saveToClipboard()
+                    _gvars.saveScreenshotToClipboard()
                 }
                 else
                 {

--- a/src/game/GameResults.as
+++ b/src/game/GameResults.as
@@ -134,6 +134,7 @@ package game
         {
             // Add keyboard navigation
             stage.addEventListener(KeyboardEvent.KEY_DOWN, eventHandler);
+            stage.addEventListener(KeyboardEvent.KEY_UP, eventHandler);
 
             // Add Mouse Move for graphs
             stage.addEventListener(MouseEvent.MOUSE_MOVE, e_graphHover);
@@ -213,7 +214,7 @@ package game
             // Song Results Buttons
             navScreenShot = new BoxIcon(this, 522, 6, 32, 32, new iconPhoto(), eventHandler);
             navScreenShot.setIconColor("#E2FEFF");
-            navScreenShot.setHoverText(_lang.string("game_results_queue_save_screenshot"), "bottom");
+            setContextualTakeScreenshotHovertext(false);
 
             navSaveReplay = new BoxIcon(this, 485, 6, 32, 32, new iconVideo(), eventHandler);
             navSaveReplay.setIconColor("#E2FEFF");
@@ -262,6 +263,7 @@ package game
         {
             // Remove keyboard navigation
             stage.removeEventListener(KeyboardEvent.KEY_DOWN, eventHandler);
+            stage.removeEventListener(KeyboardEvent.KEY_UP, eventHandler);
 
             // Remove Mouse Move for graphs
             stage.removeEventListener(MouseEvent.MOUSE_MOVE, e_graphHover);
@@ -703,11 +705,22 @@ package game
                     target = navMenu;
                     stage.removeEventListener(KeyboardEvent.KEY_DOWN, eventHandler);
                 }
-                else if (keyCode == Keyboard.C && e.controlKey)
+                else if (e.ctrlKey)
                 {
-                    _gvars.copyScreenshot();
+                    setContextualTakeScreenshotHovertext(true);
                 }
             }
+
+            if (e.type == "keyUp" && !_mp.gameplayPlayingStatusResults())
+            {
+                if (!e.ctrlKey)
+                {
+                    setContextualTakeScreenshotHovertext(false);
+                }
+
+                return;
+            }
+
 
             if (!target)
                 return;
@@ -720,12 +733,20 @@ package game
 
             else if (target == navScreenShot)
             {
-                var ext:String = "";
-                if (resultIndex >= 0)
+                if (e.ctrlKey)
                 {
-                    ext = songResults[resultIndex].screenshot_path;
+                    _gvars.saveToClipboard()
                 }
-                _gvars.takeScreenShot(ext);
+                else
+                {
+                    var ext:String = "";
+                    if (resultIndex >= 0)
+                    {
+                        ext = songResults[resultIndex].screenshot_path;
+                    }
+                    _gvars.takeScreenShot(ext);
+                }
+
             }
 
             else if (target == navPrev)
@@ -1418,6 +1439,23 @@ package game
         {
             removeLoaderListeners(replayLoadComplete, replayLoadError);
             Alert.add(_lang.string("error_server_connection_failure"), 120, Alert.RED);
+        }
+
+
+        /**
+         * Set the hover text for the screenshot button based on conext.
+         * @param isClipboardMode Whether to use the clipboard tooltip or not.
+         */
+        private function setContextualTakeScreenshotHovertext(isClipboardMode:Boolean):void
+        {
+            if (isClipboardMode)
+            {
+                navScreenShot.setHoverText(null);
+            }
+            else
+            {
+                navScreenShot.setHoverText(_lang.string("game_results_queue_save_screenshot"), "bottom");
+            }
         }
 
     }


### PR DESCRIPTION
- Finish playing game.
- Press `CTRL + C`
- Paste in discord.

Requirements:
- Add language string `copy_image_to_clipboard`
- Add language string `game_results_queue_save_screenshot_clipboard_hint` to include tip about the CTRL key, leave old string as to not break old engines.