### PR TITLE
fix MP UI bug with various elements

### DIFF
--- a/src/game/GameplayDisplay.as
+++ b/src/game/GameplayDisplay.as
@@ -1628,9 +1628,6 @@ package game
             mpCombo = [];
             mpHeader = [];
 
-            if (!options.displayMPUI && !mpSpectate)
-                return;
-
             for each (var user:User in options.mpRoom.players)
             {
                 if (user.id == options.mpRoom.connection.currentUser.id)
@@ -1643,6 +1640,9 @@ package game
                         mpJudge[user.playerIdx] = player1Judge;
                     continue;
                 }
+
+                if (!options.displayMPUI)
+                    continue;
 
                 if (options.displayMPPA)
                 {


### PR DESCRIPTION
Fixes MP bug where player1's (self) UI elements would display in incorrect location when display MP UI option was disabled.
this covers PA Window, Combo, and Judge for player1 in editor and in gameplay.

resolves #341 