### PR TITLE
Add raw goods and rank sorting

### DIFF
--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -19,6 +19,7 @@ package menu
     import classes.SongPlayerBytes;
     import classes.SongPreview;
     import classes.SongQueueItem;
+    import classes.User;
     import classes.chart.Song;
     import classes.ui.BoxButton;
     import classes.ui.BoxIcon;
@@ -51,7 +52,6 @@ package menu
     import popups.PopupQueueManager;
     import popups.PopupSongNotes;
     import popups.PopupHighscores;
-    import classes.User;
 
     public class MenuSongSelection extends MenuPanel
     {

--- a/src/menu/MenuSongSelection.as
+++ b/src/menu/MenuSongSelection.as
@@ -731,10 +731,19 @@ package menu
 
                 function getSongRank(song: SongInfo, activeUser: User): uint {
                     var songRank: uint = cache[song.level];
-                    if (!songRank) {
-                        songRank = activeUser.getLevelRank(song).rank;
-                        cache[song.level] = songRank;
+                    if (songRank) {
+                        return songRank;
                     }
+
+                    var songLevelRank: Object = activeUser.getLevelRank(song);
+                    if (songLevelRank == null) {
+                        songRank = 1000000000;
+                    } else {
+                        songRank = songLevelRank.rank;
+                    }
+
+                    cache[song.level] = songRank;
+
                     return songRank;
                 }
 
@@ -755,26 +764,29 @@ package menu
                 
                 function getSongRawGoods(song: SongInfo, activeUser: User): Number {
                     var songRawGoods: Number = cache[song.level];
-                    if (!songRawGoods) {
-                        var songLevelRank: Object = activeUser.getLevelRank(song);
-
-                        if (songLevelRank == null) {
-                            songRawGoods = 2000000;
-                        } else {
-                            var rawGoods: Number = songLevelRank.good + (songLevelRank.average * 1.8) + (songLevelRank.miss * 2.4) + (songLevelRank.boo * 0.2);
-                            var notesPlayed: uint = songLevelRank.perfect + songLevelRank.good + songLevelRank.average + songLevelRank.miss;
-                            var noteCount: uint = song.note_count || songLevelRank.arrows;
-
-                            if (notesPlayed < noteCount) {
-                                var implicitMisses: uint = noteCount - notesPlayed;
-                                songRawGoods = 1000000 + rawGoods + implicitMisses * 2.4;
-                            } else {
-                                songRawGoods = rawGoods;
-                            }
-                        }
-
-                        cache[song.level] = songRawGoods;
+                    if (songRawGoods) {
+                        return songRawGoods;
                     }
+
+                    var songLevelRank: Object = activeUser.getLevelRank(song);
+
+                    if (songLevelRank == null) {
+                        songRawGoods = 2000000;
+                    } else {
+                        var rawGoods: Number = songLevelRank.good + (songLevelRank.average * 1.8) + (songLevelRank.miss * 2.4) + (songLevelRank.boo * 0.2);
+                        var notesPlayed: uint = songLevelRank.perfect + songLevelRank.good + songLevelRank.average + songLevelRank.miss;
+                        var noteCount: uint = song.note_count || songLevelRank.arrows;
+
+                        if (notesPlayed < noteCount) {
+                            var implicitMisses: uint = noteCount - notesPlayed;
+                            songRawGoods = 1000000 + rawGoods + implicitMisses * 2.4;
+                        } else {
+                            songRawGoods = rawGoods;
+                        }
+                    }
+
+                    cache[song.level] = songRawGoods;
+                    
                     return songRawGoods;
                 }
 


### PR DESCRIPTION
This PR adds two new songlist sorting options, "raw goods" and "rank".
"Raw goods" sorting doesn't sort unplayed and unfinished songs in alt engines.

Closes #195 