### PR TITLE
Add MP Quit Coloring

### DIFF
--- a/src/game/controls/MPFFRScoreCompare.as
+++ b/src/game/controls/MPFFRScoreCompare.as
@@ -119,6 +119,7 @@ internal class PlayerLabel extends Sprite
 
     private var _lastPosition:int = -1;
     private var _lastScore:int = -1;
+    private var _hasQuit:Boolean = false;
 
     public function PlayerLabel(room:MPRoomFFR, data:MPMatchFFRUser):void
     {
@@ -165,12 +166,13 @@ internal class PlayerLabel extends Sprite
             this.alpha = data.alive ? 1 : 0.5;
             isAlive = data.alive;
         }
-        else {
+        else if (!_hasQuit) {
             // check if user has quit the match (but is still connected)
             const gameState:String = data.room.player_state_map[data.user.uid].game_state;
 
             if (gameState != "game" && gameState != "loading") {
                 txtUsername.fontColor = MPColors.USER_LEAVE;
+                _hasQuit = true;
             }
         }
     }

--- a/src/game/controls/MPFFRScoreCompare.as
+++ b/src/game/controls/MPFFRScoreCompare.as
@@ -93,6 +93,7 @@ package game.controls
     }
 }
 
+import classes.mp.MPColors;
 import classes.mp.MPUser;
 import classes.mp.Multiplayer;
 import classes.mp.mode.ffr.MPMatchFFRUser;
@@ -163,6 +164,14 @@ internal class PlayerLabel extends Sprite
         {
             this.alpha = data.alive ? 1 : 0.5;
             isAlive = data.alive;
+        }
+        else {
+            // check if user has quit the match (but is still connected)
+            const gameState:String = data.room.player_state_map[data.user.uid].game_state;
+
+            if (gameState != "game" && gameState != "loading") {
+                txtUsername.fontColor = MPColors.USER_LEAVE;
+            }
         }
     }
 


### PR DESCRIPTION
Adds a color change on the MP score display for when another player quits/drops out of a song. 
Uses the color from `MPColors.USER_LEAVE`.