### PR TITLE
Fix multiplayer connection handshake timeouts

### DIFF
--- a/src/com/worlize/websocket/WebSocket.as
+++ b/src/com/worlize/websocket/WebSocket.as
@@ -793,6 +793,7 @@ package com.worlize.websocket
             }
 
             socket.writeMultiByte(text, 'us-ascii');
+            socket.flush();
 
             handshakeTimer.stop();
             handshakeTimer.reset();


### PR DESCRIPTION
In some configurations (depending on the player's OS or flash runtime) the MP websocket handshake may never actually get sent before FFR starts waiting for a response, which could result in no activity and eventually a timeout error when trying to connect to multiplayer.