### PR TITLE
Add slider to control Accuracy Bar's ADJUST_TRANSFORM alpha channel

### DIFF
--- a/src/classes/User.as
+++ b/src/classes/User.as
@@ -153,6 +153,7 @@ package classes
         public var frameRate:int = 60;
         public var songRate:Number = 1;
         public var gameLayout:Object = {};
+        public var accuracyBarFadeFactor:Number = 0.95;
 
         //- Permissions
         public var isActiveUser:Boolean;
@@ -724,6 +725,9 @@ package classes
             if (_settings.noteScale != null)
                 this.noteScale = _settings.noteScale;
 
+            if (_settings.accuracyBarFadeFactor != null)
+                this.accuracyBarFadeFactor = _settings.accuracyBarFadeFactor;
+
             if (_settings.screencutPosition != null)
                 this.screencutPosition = _settings.screencutPosition;
 
@@ -851,6 +855,7 @@ package classes
 
             gameSave.keys = [this.keyLeft, this.keyDown, this.keyUp, this.keyRight, this.keyRestart, this.keyQuit, this.keyOptions];
 
+            gameSave.accuracyBarFadeFactor = this.accuracyBarFadeFactor;
             gameSave.receptorSpeed = this.receptorSpeed;
             gameSave.judgeSpeed = this.judgeSpeed;
             gameSave.judgeScale = this.judgeScale;

--- a/src/game/GameOptions.as
+++ b/src/game/GameOptions.as
@@ -22,6 +22,7 @@ package game
         public var screencutPosition:Number = 0.5;
         public var mods:Array = [];
         public var noteskin:int = 1;
+        public var accuracyBarFadeFactor:Number = 0.95;
 
         public var offsetGlobal:Number = 0;
         public var offsetJudge:Number = 0;
@@ -106,6 +107,7 @@ package game
             mods = user.activeMods.concat(user.activeVisualMods);
             modCache = null;
             noteskin = user.activeNoteskin;
+            accuracyBarFadeFactor = user.accuracyBarFadeFactor;
 
             offsetGlobal = user.GLOBAL_OFFSET;
             offsetJudge = user.JUDGE_OFFSET;
@@ -241,6 +243,7 @@ package game
             settings["frameRate"] = frameRate;
             settings["songRate"] = songRate;
             settings["visual"] = mods;
+            settings["accuracyBarFadeFactor"] = accuracyBarFadeFactor;
 
             if (isolation)
             {
@@ -294,6 +297,7 @@ package game
             mods = settings["visual"] || [];
             modCache = null;
             noteskin = settings["noteskin"] != null ? settings["noteskin"] : 1;
+            accuracyBarFadeFactor = settings["accuracyBarFadeFactor"] || 0.95;
 
             offsetGlobal = settings["viewOffset"] || 0;
             offsetJudge = settings["judgeOffset"] || 0;

--- a/src/game/controls/AccuracyBar.as
+++ b/src/game/controls/AccuracyBar.as
@@ -11,7 +11,7 @@ package game.controls
     public class AccuracyBar extends GameControl
     {
         private static var CLEAR_TRANSFORM:ColorTransform = new ColorTransform(1, 1, 1, 0);
-        private static var ADJUST_TRANSFORM:ColorTransform = new ColorTransform(1, 1, 1, 0.95)
+        private static var ADJUST_TRANSFORM:ColorTransform;
 
         private var options:GameOptions;
 
@@ -51,6 +51,7 @@ package game.controls
             _colors[5] = options.judgeColors[3];
 
             // Setup ColorTransform for Fade
+            ADJUST_TRANSFORM = new ColorTransform(1, 1, 1, options.accuracyBarFadeFactor);
             _renderTarget = new Shape();
             _alphaArea = new Rectangle(0, 0, _width, _height);
 

--- a/src/popups/settings/SettingsTabVisuals.as
+++ b/src/popups/settings/SettingsTabVisuals.as
@@ -40,6 +40,9 @@ package popups.settings
 
         private var optionDisplays:Array;
 
+        private var optionAccuracyBarFadeFactor:BoxSlider;
+        private var textAccuracyBarFadeFactor:Text;
+
         private var optionReceptorSpeed:BoxSlider;
         private var textReceptorSpeed:Text;
 
@@ -94,6 +97,11 @@ package popups.settings
                 gameDisplayCheck.display = gameUIArray[i];
                 optionDisplays.push(gameDisplayCheck);
                 yOff += 19;
+
+                if (gameUIArray[i] == "ACCURACY_BAR")
+                {
+                    yOff = drawAccuracyBarFadeFactor(xOff, yOff, container);
+                }
 
                 if (gameUIArray[i] == "RECEPTOR_ANIMATIONS")
                 {
@@ -170,6 +178,20 @@ package popups.settings
         }
 
 
+        private function drawAccuracyBarFadeFactor(xOff:int, yOff:int, container:ScrollPaneContent):int
+        {
+            new Text(container, xOff + 23, yOff, _lang.string("options_accuracy_bar_fade_factor"));
+            yOff += 22;
+
+            optionAccuracyBarFadeFactor = new BoxSlider(container, xOff + 23, yOff + 3, 100, 10, changeHandler);
+            optionAccuracyBarFadeFactor.minValue = 0.5;
+            optionAccuracyBarFadeFactor.maxValue = 0.99;
+
+            textAccuracyBarFadeFactor = new Text(container, xOff + 128, yOff - 2);
+            yOff += 20;
+            return yOff + 4;
+        }
+
         private function drawReceptorSpeed(xOff:int, yOff:int, container:ScrollPaneContent):int
         {
             new Text(container, xOff + 23, yOff, _lang.string("options_receptor_speed"));
@@ -221,6 +243,9 @@ package popups.settings
                 item.checked = (_gvars.activeUser["DISPLAY_" + item.display]);
             }
 
+            optionAccuracyBarFadeFactor.slideValue = _gvars.activeUser.accuracyBarFadeFactor;
+            textAccuracyBarFadeFactor.text = (_gvars.activeUser.accuracyBarFadeFactor * 100).toFixed(0) + "%";
+
             optionReceptorSpeed.slideValue = _gvars.activeUser.receptorSpeed;
             textReceptorSpeed.text = _gvars.activeUser.receptorSpeed.toFixed(2) + "x";
 
@@ -271,6 +296,12 @@ package popups.settings
 
         override public function changeHandler(e:Event):void
         {
+            if (e.target == optionAccuracyBarFadeFactor)
+            {
+                _gvars.activeUser.accuracyBarFadeFactor = Math.round(optionAccuracyBarFadeFactor.slideValue * 100) / 100;
+                textAccuracyBarFadeFactor.text = (_gvars.activeUser.accuracyBarFadeFactor * 100).toFixed(0) + "%";
+            }
+
             if (e.target == optionJudgeSpeed)
             {
                 _gvars.activeUser.judgeSpeed = (Math.round((optionJudgeSpeed.slideValue * 100) / 5) * 5) / 100; // Snap to 0.05 intervals.


### PR DESCRIPTION
Closes https://github.com/flashflashrevolution/rCubed/issues/389.

This PR adds a slider next to the accuracy bar toggle in the Game UI Visuals tab of the game's settings to change how quickly judgements fade away completely from the accuracy bar.

Value restricted to 0.5 ≤ x ≤ 0.99 as 0.5 barely holds 4 judgements at the same time while 1 is just impractical... Maybe if the novelty of seeing a live "top-down" graph of all judgements is interesting enough then it could be allowed.
